### PR TITLE
Fix CPU profiler latency

### DIFF
--- a/ts/test/test-worker-threads.ts
+++ b/ts/test/test-worker-threads.ts
@@ -10,10 +10,8 @@ describe('Worker Threads', () => {
   // eslint-ignore-next-line prefer-array-callback
   it('should work when propagated to a worker through -r flag', function () {
     this.timeout(5000);
-    return exec('node', ['-r', './', './out/test/worker.js']).then(
-      ({stdout}) => {
-        assert.strictEqual(stdout, 'it works!\nit works!\n');
-      }
-    );
+    return exec('node', ['./out/test/worker.js']).then(({stdout}) => {
+      assert.strictEqual(stdout, 'it works!\nit works!\n');
+    });
   });
 });


### PR DESCRIPTION
This introduces an argument to the stop function to tell it to start a new profile, by calling the stop function repeatedly you can keep getting more profiles. By making this an argument it allows for the ordering of start and stop to be rearranged depending on the Node.js version. This is important as pre-16 needs to dispose the profiler between profiles to avoid a memory leak, while 16+ needs to start the next profile before stopping the previous to prevent a latency spike due to tearing down and starting up the symbolizer thread on each stop and start.