### PR TITLE
Update CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,35 +3,27 @@ version: 2.1
 orbs:
   win: circleci/windows@2.2.0
 
-node-core-base: &node-core-base
-  resource_class: small
-  working_directory: ~/dd-pprof
-  steps:
-    - checkout
-    - &restore-npm-cache
-      restore_cache:
-        key: npm-{{ .Environment.CIRCLE_JOB }}-{{ checksum "package.json" }}
-    - &npm-install
-      run:
-        name: Install dependencies
-        command: npm install
-    - &save-npm-cache
-      save_cache:
-        key: npm-{{ .Environment.CIRCLE_JOB }}-{{ checksum "package.json" }}
-        paths:
-          - ./node_modules
-          - ./package-lock.json
-    - &npm-rebuild
-      run:
-        name: Compile native code
-        command: npm run rebuild
-    - &npm-test
-      run:
-        name: Unit tests
-        command: npm test
-    - store_test_results:
-        path: test-results
-        when: always
+commands:
+  checkout-and-yarn-install:
+    steps:
+      - checkout
+      - &yarn-versions
+        run:
+          name: Versions
+          command: yarn versions
+      - &restore-yarn-cache
+        restore_cache:
+          key: yarn-{{ .Environment.CIRCLE_JOB }}-{{ checksum "package.json" }}
+      - &yarn-install
+        run:
+          name: Install dependencies
+          command: yarn install --ignore-engines
+      - &save-yarn-cache
+        save_cache:
+          key: yarn-{{ .Environment.CIRCLE_JOB }}-{{ checksum "package.json" }}
+          paths:
+            - ./node_modules
+            - ./yarn.lock
 
 prebuild-linux-base: &prebuild-linux-base
   docker:
@@ -41,14 +33,11 @@ prebuild-linux-base: &prebuild-linux-base
   working_directory: ~/dd-pprof
   resource_class: small
   steps:
-    - checkout
-    - *restore-npm-cache
-    - *npm-install
-    - *save-npm-cache
-    - &npm-prebuild
+    - checkout-and-yarn-install
+    - &yarn-prebuild
       run:
         name: Compile prebuilt binaries
-        command: npm run prebuild
+        command: yarn prebuild
     - &persist-prebuilds
       persist_to_workspace:
         root: ~/dd-pprof
@@ -60,24 +49,50 @@ prebuild-linux-ia32-base: &prebuild-linux-ia32-base
   steps:
     - run:
         name: Install job dependencies
-        command: apt-get update && apt-get install -y g++-multilib
-    - checkout
-    - *restore-npm-cache
-    - *npm-install
-    - *save-npm-cache
-    - *npm-prebuild
+        command: apt-get update && apt-get install -y g++-multilib python3
+    - checkout-and-yarn-install
+    - *yarn-prebuild
     - *persist-prebuilds
+
+test-prebuild-linux-base: &test-prebuild-linux-base
+  docker:
+    - image: node:slim
+  working_directory: ~/dd-pprof
+  resource_class: small
+  steps:
+    - checkout-and-yarn-install
+    - attach_workspace:
+        at: ~/dd-pprof
+    - &yarn-test
+      run:
+        name: Unit tests
+        command: yarn test
+
+test-prebuild-alpine-base: &test-prebuild-alpine-base
+  docker:
+    - image: node:slim
+  working_directory: ~/dd-pprof
+  resource_class: small
+  steps:
+    - run:
+        name: Install job dependencies
+        command: apk add g++ git make python3
+    - checkout-and-yarn-install
+    - attach_workspace:
+        at: ~/dd-pprof
+    - &yarn-test
+      run:
+        name: Unit tests
+        command: yarn test
 
 prebuild-darwin-base: &prebuild-darwin-base
   macos:
     xcode: "12.2.0"
   working_directory: ~/dd-pprof
   steps:
-    - checkout
-    - *restore-npm-cache
-    - *npm-install
-    - *save-npm-cache
-    - *npm-prebuild
+    - checkout-and-yarn-install
+    - *yarn-prebuild
+    - *yarn-test
     - *persist-prebuilds
 
 prebuild-win32-base: &prebuild-win32-base
@@ -86,24 +101,10 @@ prebuild-win32-base: &prebuild-win32-base
     size: medium
   working_directory: ~/dd-pprof
   steps:
-    - checkout
-    - *restore-npm-cache
-    - *npm-install
-    - *save-npm-cache
-    - *npm-prebuild
+    - checkout-and-yarn-install
+    - *yarn-prebuild
+    - *yarn-test
     - *persist-prebuilds
-
-prebuild-job: &prebuild-job
-  filters:
-    branches:
-      only:
-        - main
-        - /v\d+\.\d+/
-        - /v\d+\.x/
-        - /.*native.*/
-        - /^node-\d+/
-        - /prebuild/
-        - /.*/
 
 jobs:
   # Linting
@@ -114,185 +115,154 @@ jobs:
     working_directory: ~/dd-pprof
     resource_class: small
     steps:
-      - checkout
-      - *restore-npm-cache
-      - *npm-install
-      - *save-npm-cache
+      - checkout-and-yarn-install
       - run:
           name: Lint
-          command: npm run lint
-
-  # Core tests
-
-  node-core-12:
-    <<: *node-core-base
-    docker:
-      - image: node:12
-
-  node-core-14:
-    <<: *node-core-base
-    docker:
-      - image: node:14
-
-  node-core-16:
-    <<: *node-core-base
-    docker:
-      - image: node:16
-
-  node-core-latest:
-    <<: *node-core-base
-    docker:
-      - image: node
-
-  # Windows tests
-
-  node-core-windows:
-    executor:
-      name: win/default
-      size: medium
-    working_directory: ~/dd-pprof
-    steps:
-      - checkout
-      - *restore-npm-cache
-      - *npm-install
-      - *save-npm-cache
-      - *npm-rebuild
-      - *npm-test
+          command: yarn lint
 
   # Prebuilds (linux x64)
 
   linux-x64-16:
     <<: *prebuild-linux-base
     docker:
-      - image: node:12.0.0
+      # from node:12.0.0 on 2021-08-30
+      - image: node@sha256:c88ef4f7ca8d52ed50366d821e104d029f43e8686120a29541ce0371f333453f
     environment:
       - ARCH=x64
       - NODE_VERSIONS=15 - 17
-
-  linux-x64-14:
-    <<: *prebuild-linux-base
-    environment:
-      - ARCH=x64
-      - NODE_VERSIONS=14
 
   linux-x64-12:
     <<: *prebuild-linux-base
     environment:
       - ARCH=x64
+      - NODE_VERSIONS=12 - 14
+
+  # Tests (linux x64)
+
+  linux-x64-latest-test:
+    <<: *test-prebuild-linux-base
+    docker:
+      - image: node
+
+  linux-x64-16-test:
+    <<: *test-prebuild-linux-base
+    docker:
+      - image: node:16
+
+  linux-x64-14-test:
+    <<: *test-prebuild-linux-base
+    docker:
+      - image: node:14
+
+  linux-x64-12-test:
+    <<: *test-prebuild-linux-base
+    docker:
+      - image: node:12
+
+  # Prebuilds (linux ia32)
+
+  linux-ia32:
+    <<: *prebuild-linux-ia32-base
+    environment:
+      - ARCH=ia32
       - NODE_VERSIONS=12 - 13
 
   # Prebuilds (alpine x64)
 
   alpine-x64: &alpine-base
     docker:
-      - image: node:alpine
+      # from node:alpine on 2021-08-30
+      - image: node@sha256:1ee1478ef46a53fc0584729999a0570cf2fb174fbfe0370edbf09680b2378b56
     working_directory: ~/dd-pprof
     resource_class: small
     steps:
       - run:
           name: Install job dependencies
           command: apk add g++ git make python3
-      - checkout
-      - *restore-npm-cache
-      - *npm-install
-      - *save-npm-cache
-      - *npm-rebuild
-      - *npm-test
+      - checkout-and-yarn-install
+      - &yarn-rebuild
+          run:
+            name: Compile native code
+            command: yarn rebuild
+      - *yarn-test
+
+  # Tests (alpine x64)
+
+  alpine-x64-latest-test:
+    <<: *test-prebuild-alpine-base
+    docker:
+      - image: node:alpine
+
+  alpine-x64-16-test:
+    <<: *test-prebuild-alpine-base
+    docker:
+      - image: node:16-alpine
+
+  alpine-x64-14-test:
+    <<: *test-prebuild-alpine-base
+    docker:
+      - image: node:14-alpine
+
+  alpine-x64-12-test:
+    <<: *test-prebuild-alpine-base
+    docker:
+      - image: node:12-alpine
 
   # Prebuilds (alpine ia32)
 
   alpine-ia32:
     <<: *alpine-base
     docker:
-      - image: i386/node:alpine
+      # from i386/node:alpine on 2021-08-30
+      - image: i386/node@sha256:c81d659f51a11aea6d73598fce064cf087b21caf9046fbf34530d9f1d43c8ec8
 
-  # Prebuilds (linux ia32)
+  # Tests (alpine ia32)
 
-  linux-ia32-12:
-    <<: *prebuild-linux-ia32-base
+  alpine-ia32-13-test:
+    <<: *test-prebuild-alpine-base
+    docker:
+      - image: i386/node:13-alpine
+
+  alpine-ia32-12-test:
+    <<: *test-prebuild-alpine-base
+    docker:
+      - image: i386/node:12-alpine
+
+  # Prebuilds (darwin)
+
+  macos-intel:
+    working_directory: ~/dd-pprof
+    steps:
+      - checkout-and-yarn-install
+      - *yarn-prebuild
+      - *yarn-test
+      - *persist-prebuilds
+    macos:
+      xcode: "12.2.0"
     environment:
-      - ARCH=ia32
-      - NODE_VERSIONS=12 - 13
+      - ARCH=ia32,x64
+      - NODE_VERSIONS=12 - 17
 
-  # Prebuilds (darwin x64)
-
-  mac-x64-16:
-    <<: *prebuild-darwin-base
+  macos-apple:
+    working_directory: ~/dd-pprof
+    steps:
+      - checkout-and-yarn-install
+      - *yarn-prebuild
+      # TODO: run tests when CircleCI adds Apple silicon executors
+      - *persist-prebuilds
+    macos:
+      xcode: "12.5.1"
     environment:
-      - ARCH=x64
-      - NODE_VERSIONS=16 - 17
-
-  mac-x64-14:
-    <<: *prebuild-darwin-base
-    environment:
-      - ARCH=x64
-      - NODE_VERSIONS=14 - 15
-
-  mac-x64-12:
-    <<: *prebuild-darwin-base
-    environment:
-      - ARCH=x64
-      - NODE_VERSIONS=12 - 13
-
-  # Prebuilds (darwin ia32)
-
-  mac-ia32-16:
-    <<: *prebuild-darwin-base
-    environment:
-      - ARCH=ia32
-      - NODE_VERSIONS=16 - 17
-
-  mac-ia32-14:
-    <<: *prebuild-darwin-base
-    environment:
-      - ARCH=ia32
-      - NODE_VERSIONS=14 - 15
-
-  mac-ia32-12:
-    <<: *prebuild-darwin-base
-    environment:
-      - ARCH=ia32
-      - NODE_VERSIONS=12 - 13
+      - ARCH=arm64
+      - NODE_VERSIONS=12 - 17
 
   # Prebuilds (win32 x64)
 
-  win-x64-16:
+  windows:
     <<: *prebuild-win32-base
     environment:
-      - ARCH=x64
-      - NODE_VERSIONS=16 - 17
-
-  win-x64-14:
-    <<: *prebuild-win32-base
-    environment:
-      - ARCH=x64
-      - NODE_VERSIONS=14 - 15
-
-  win-x64-12:
-    <<: *prebuild-win32-base
-    environment:
-      - ARCH=x64
-      - NODE_VERSIONS=12 - 13
-
-  # Prebuilds (win32 ia32)
-
-  win-ia32-16:
-    <<: *prebuild-win32-base
-    environment:
-      - ARCH=ia32
-      - NODE_VERSIONS=16 - 17
-
-  win-ia32-14:
-    <<: *prebuild-win32-base
-    environment:
-      - ARCH=ia32
-      - NODE_VERSIONS=14 - 15
-
-  win-ia32-12:
-    <<: *prebuild-win32-base
-    environment:
-      - ARCH=ia32
-      - NODE_VERSIONS=12 - 13
+      - ARCH=ia32,x64
+      - NODE_VERSIONS=12 - 17
 
   # Prebuild Artifacts
 
@@ -302,94 +272,83 @@ jobs:
     working_directory: ~/dd-pprof
     resource_class: small
     steps:
-      - checkout
+      - checkout-and-yarn-install
       - attach_workspace:
           at: ~/dd-pprof
-      - *restore-npm-cache
-      - *npm-install
-      - *save-npm-cache
       - run:
           name: Create prebuilds archive
-          command: npm run prebuilds
+          command: yarn prebuilds
       - store_artifacts:
           path: ./prebuilds.tgz
       - store_artifacts:
-          path: ./prebuilds.tgz.sha1
+          path: ./prebuilds.tgz.sha256
 
 workflows:
   version: 2
   build:
-    jobs:
-      - lint
-      - node-core-12
-      - node-core-14
-      - node-core-16
-      - node-core-latest
-      - node-core-windows
-  prebuild:
-    jobs:
+    jobs: &jobs
       # Linux x64
-      - linux-x64-16:
-          <<: *prebuild-job
-      - linux-x64-14:
-          <<: *prebuild-job
-      - linux-x64-12:
-          <<: *prebuild-job
-      # Linux ia32
-      - linux-ia32-12:
-          <<: *prebuild-job
-      # Alpine x64
-      - alpine-x64:
-          <<: *prebuild-job
-      # Alpine ia32
-      - alpine-ia32:
-          <<: *prebuild-job
-      # Darwin x64
-      - mac-x64-16:
-          <<: *prebuild-job
-      - mac-x64-14:
-          <<: *prebuild-job
-      - mac-x64-12:
-          <<: *prebuild-job
-      # Darwin ia32
-      - mac-ia32-16:
-          <<: *prebuild-job
-      - mac-ia32-14:
-          <<: *prebuild-job
-      - mac-ia32-12:
-          <<: *prebuild-job
-      # Windows x64
-      - win-x64-16:
-          <<: *prebuild-job
-      - win-x64-14:
-          <<: *prebuild-job
-      - win-x64-12:
-          <<: *prebuild-job
-      # Windows ia32
-      - win-ia32-16:
-          <<: *prebuild-job
-      - win-ia32-14:
-          <<: *prebuild-job
-      - win-ia32-12:
-          <<: *prebuild-job
-      # Artifacts
-      - prebuilds:
+      - linux-x64-16
+      - linux-x64-12
+      - linux-x64-latest-test:
           requires:
             - linux-x64-16
-            - linux-x64-14
+      - linux-x64-16-test:
+          requires:
+            - linux-x64-16
+      - linux-x64-14-test:
+          requires:
             - linux-x64-12
-            - linux-ia32-12
+      - linux-x64-12-test:
+          requires:
+            - linux-x64-12
+      # Linux ia32
+      - linux-ia32
+      - alpine-x64
+      - alpine-x64-latest-test:
+          requires:
             - alpine-x64
+      - alpine-x64-16-test:
+          requires:
+            - alpine-x64
+      - alpine-x64-14-test:
+          requires:
+            - alpine-x64
+      - alpine-x64-12-test:
+          requires:
+            - alpine-x64
+      - alpine-ia32
+      - alpine-ia32-13-test:
+          requires:
             - alpine-ia32
-            - mac-x64-16
-            - mac-x64-14
-            - mac-x64-12
-            - mac-ia32-16
-            - mac-ia32-14
-            - mac-ia32-12
-            - win-x64-16
-            - win-x64-14
-            - win-x64-12
-            - win-ia32-16
-            - win-ia32-14
-            - win-ia32-12
+      - alpine-ia32-12-test:
+          requires:
+            - alpine-ia32
+      - macos-intel
+      - macos-apple
+      - windows
+      - prebuilds:
+          requires:
+            - linux-x64-latest-test
+            - linux-x64-16-test
+            - linux-x64-14-test
+            - linux-x64-12-test
+            - linux-ia32
+            - alpine-x64-latest-test
+            - alpine-x64-16-test
+            - alpine-x64-14-test
+            - alpine-x64-12-test
+            - alpine-ia32-13-test
+            - alpine-ia32-12-test
+            - macos-intel
+            - macos-apple
+            - windows
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - main
+    jobs: *jobs

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "prepare": "npm run compile",
     "prepublishOnly": "node scripts/prepublish.js",
     "pretest": "npm run compile && npm run rebuild",
-    "posttest": "npm run check && npm run license-check",
+    "posttest": "npm run license-check",
     "proto": "npm run proto:profile",
     "proto:profile": "mkdir -p proto && pbjs -t static-module -w commonjs -o proto/profile.js third_party/proto/profile.proto && pbts -o proto/profile.d.ts proto/profile.js",
     "license-check": "jsgl --local .",


### PR DESCRIPTION
This adds Apple Silicon support and runs tests across more version and OS combos. I've also taken the check task out of `posttest` as the `gts` module is currently broken by `prettier` making breaking changes in a minor.