### PR TITLE
[security] Bump protobufjs to version 6.11.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "node-gyp-build": "^3.9.0",
         "p-limit": "^3.0.0",
         "pify": "^5.0.0",
-        "protobufjs": "~6.11.0",
+        "protobufjs": "~6.11.3",
         "rimraf": "^3.0.2",
         "semver": "^7.3.5",
         "source-map": "^0.7.3",
@@ -4772,9 +4772,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "6.11.2",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.2.tgz",
-      "integrity": "sha512-4BQJoPooKJl2G9j3XftkIXjoC9C0Av2NOrWmbLWT1vH32GcSUHjM0Arra6UfTsVyfMAuFzaLucXn1sadxJydAw==",
+      "version": "6.11.3",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
+      "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
       "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -10024,9 +10024,9 @@
       "dev": true
     },
     "protobufjs": {
-      "version": "6.11.2",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.2.tgz",
-      "integrity": "sha512-4BQJoPooKJl2G9j3XftkIXjoC9C0Av2NOrWmbLWT1vH32GcSUHjM0Arra6UfTsVyfMAuFzaLucXn1sadxJydAw==",
+      "version": "6.11.3",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
+      "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "node-gyp-build": "^3.9.0",
     "p-limit": "^3.0.0",
     "pify": "^5.0.0",
-    "protobufjs": "~6.11.0",
+    "protobufjs": "~6.11.3",
     "rimraf": "^3.0.2",
     "semver": "^7.3.5",
     "source-map": "^0.7.3",


### PR DESCRIPTION
The PR is essentially to bump [protobufjs](https://github.com/protobufjs/protobuf.js) to version [6.11.3](https://github.com/caolan/async/blob/master/CHANGELOG.md#v322) to fix a [prototype pollution exploit](https://security.snyk.io/vuln/SNYK-JS-PROTOBUFJS-2441248) found in versions < 6.11.3 . 
The vulnerability is labelled as `High Severity`.