### PR TITLE
Eliminate install script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,8 +13,14 @@ commands:
       - restore_cache:
           key: yarn-{{ .Environment.CIRCLE_JOB }}-{{ checksum "package.json" }}
       - run:
+          name: Hide gyp file
+          command: mv binding.gyp binding.gyp.bak
+      - run:
           name: Install dependencies
           command: yarn install --ignore-engines
+      - run:
+          name: Restore gyp file
+          command: mv binding.gyp.bak binding.gyp
       - save_cache:
           key: yarn-{{ .Environment.CIRCLE_JOB }}-{{ checksum "package.json" }}
           paths:

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "@datadog/pprof",
       "version": "0.5.1",
-      "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "delay": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "main": "out/src/index.js",
   "types": "out/src/index.d.ts",
   "scripts": {
-    "install": "(node scripts/should_rebuild && node-gyp-build) || exit 0",
     "rebuild": "node-gyp rebuild --jobs=max",
     "test:js": "nyc mocha out/test/test-*.js",
     "test:cpp": "node scripts/cctest.js",
@@ -76,9 +75,7 @@
   "files": [
     "out/src",
     "out/third_party/cloud-debug-nodejs",
-    "bindings",
     "proto",
-    "binding.gyp",
     "package-lock.json",
     "package.json",
     "README.md",

--- a/scripts/should_rebuild.js
+++ b/scripts/should_rebuild.js
@@ -1,8 +1,0 @@
-'use strict'
-
-const { CI, INIT_CWD, PWD } = process.env
-
-// skip for local development, CI, or very old package managers without INIT_CWD
-if (CI === 'true' || !INIT_CWD || INIT_CWD.includes(PWD)) {
-  process.exitCode = 1
-}


### PR DESCRIPTION
Because there are prebuilds for all supported platforms, we can exclude the binding.gyp from the package and remove the install script from package.json