### PR TITLE
Publish from CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - v[0-9]+.x
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: npm
+    env:
+      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v3
+        with:
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm publish
+      - id: pkg
+        run: |
+          content=`cat ./package.json | tr '\n' ' '`
+          echo "::set-output name=json::$content"
+      - run: |
+          git tag v${{ fromJson(steps.pkg.outputs.json).version }}
+          git push origin v${{ fromJson(steps.pkg.outputs.json).version }}


### PR DESCRIPTION
Adding an action to publish from CI. Will need to make sure repo settings has access to the key before it will work.

After this lands, the process for releasing will be to manually create a PR with a package.json version bump and the desired commits from main to a vN.x branch where N is the major version. That PR will have the same review process as any PR targeting main.