### PR TITLE
Remove concurrency cancel from release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,10 +5,6 @@ on:
     branches:
       - v[0-9]+.x
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
-  cancel-in-progress: true
-
 jobs:
   build:
     uses: Datadog/action-prebuildify/.github/workflows/build.yml@main


### PR DESCRIPTION
action-prebuildify has its own concurrency control which makes the one here cancel it out. Since publish depends on the build workflow anyway, it's best to just remove it altogether.