### PR TITLE
Fix profile milli/micro/nanosecond conversions

### DIFF
--- a/ts/src/cpu-profiler.ts
+++ b/ts/src/cpu-profiler.ts
@@ -96,7 +96,7 @@ export default class CpuProfiler extends NativeCpuProfiler {
       targetNode = timeProfile.topDownRoot;
     }
 
-    const intervalMicros = 1000 / (this.frequency as number);
+    const intervalMicros = 1000000 / (this.frequency as number);
     return serializeCpuProfile(timeProfile, intervalMicros);
   }
 }

--- a/ts/src/profile-serializer.ts
+++ b/ts/src/profile-serializer.ts
@@ -310,7 +310,7 @@ export function serializeTimeProfile(
     timeNanos: Date.now() * 1000 * 1000,
     durationNanos: (prof.endTime - prof.startTime) * 1000,
     periodType: timeValueType,
-    period: intervalMicros,
+    period: intervalNanos,
   };
 
   serialize(
@@ -400,7 +400,7 @@ export function serializeCpuProfile(
     timeNanos: Date.now() * 1000 * 1000,
     durationNanos: prof.endTime - prof.startTime,
     periodType: cpuValueType,
-    period: intervalMicros,
+    period: intervalNanos,
   };
 
   serialize(

--- a/ts/test/profiles-for-tests.ts
+++ b/ts/test/profiles-for-tests.ts
@@ -189,7 +189,7 @@ export const timeProfile: perftools.profiles.IProfile = Object.freeze({
   timeNanos: 0,
   durationNanos: 10 * 1000 * 1000 * 1000,
   periodType: new perftools.profiles.ValueType({type: 3, unit: 4}),
-  period: 1000,
+  period: 1000000,
 });
 
 // timeProfile is encoded then decoded to convert numbers to longs, in
@@ -607,7 +607,7 @@ export const anonymousFunctionTimeProfile: perftools.profiles.IProfile =
     timeNanos: 0,
     durationNanos: 10 * 1000 * 1000 * 1000,
     periodType: new perftools.profiles.ValueType({type: 3, unit: 4}),
-    period: 1000,
+    period: 1000000,
   });
 
 const heapWithPathLeaf1 = {
@@ -1144,5 +1144,5 @@ export const timeSourceProfile: perftools.profiles.IProfile = Object.freeze({
   timeNanos: 0,
   durationNanos: 10 * 1000 * 1000 * 1000,
   periodType: new perftools.profiles.ValueType({type: 3, unit: 4}),
-  period: 1000,
+  period: 1000000,
 });

--- a/ts/test/test-cpu-profiler.ts
+++ b/ts/test/test-cpu-profiler.ts
@@ -153,7 +153,7 @@ describe('CPU Profiler', () => {
       // verifySampleType(profile, 2, 'wall/nanoseconds');
       verifyPeriodType(profile, 'cpu/nanoseconds');
 
-      assert.strictEqual(profile.period, 1000 / 99);
+      assert.strictEqual(profile.period, 1e9 / 99);
       assert.ok(profile.durationNanos! > 0);
       assert.ok(profile.timeNanos! > 0);
 


### PR DESCRIPTION
* Fix computation of period in microseconds (this also fix x1000 under reporting of cpu time)
* Report period in nanoseconds insteads of microseconds