### PR TITLE
Fix frame vector size

### DIFF
--- a/bindings/sample.cc
+++ b/bindings/sample.cc
@@ -31,7 +31,7 @@ std::vector<uintptr_t> MakeFrames(v8::Isolate* isolate) {
   std::vector<uintptr_t> output(n);
 
   for (size_t i = 0; i < n; i++) {
-    output.push_back(reinterpret_cast<uintptr_t>(frames[i]));
+    output[i] = reinterpret_cast<uintptr_t>(frames[i]);
   }
 
   return output;


### PR DESCRIPTION
`push_back` is replaced by direct indexing since `std::vector<uintptr_t> output(n);` already creates a a vector with n elements (set to 0).