### PR TITLE
Add a ring buffer to store samples between capture and symbolization

### DIFF
--- a/bindings/profilers/cpu.hh
+++ b/bindings/profilers/cpu.hh
@@ -15,6 +15,69 @@
 
 namespace dd {
 
+class SampleBuffer
+{
+public:
+  using SamplePtr = std::unique_ptr<Sample>;
+
+  explicit SampleBuffer(size_t size) : samples_(std::make_unique<SamplePtr[]>(size)),
+                                        capacity_(size),
+                                        size_(0),
+                                        back_index_(0),
+                                        front_index_(0) {}
+
+  bool full() const { return size_ == capacity_; }
+  bool empty() const { return size_ == 0; }
+
+  SamplePtr &front()
+  {
+    return samples_[front_index_];
+  }
+
+  const SamplePtr &front() const
+  {
+    return samples_[front_index_];
+  }
+
+  void push_back(SamplePtr ptr)
+  {
+    if (full())
+    {
+      if (empty())
+      {
+        return;
+      }
+      increment(back_index_);
+      front_index_ = back_index_;
+    }
+    else
+    {
+      samples_[back_index_] = std::move(ptr);
+      increment(back_index_);
+      ++size_;
+    }
+  }
+
+  SamplePtr pop_front()
+  {
+    auto idx = front_index_;
+    increment(front_index_);
+    --size_;
+    return std::move(samples_[idx]);
+  }
+
+private:
+  void increment(size_t &idx) const
+  {
+    idx = idx + 1 == capacity_ ? 0 : idx + 1;
+  }
+  std::unique_ptr<SamplePtr[]> samples_;
+  size_t capacity_;
+  size_t size_;
+  size_t back_index_;
+  size_t front_index_;
+};
+
 class CpuProfiler : public Nan::ObjectWrap {
   friend class CodeMap;
 
@@ -23,7 +86,7 @@ class CpuProfiler : public Nan::ObjectWrap {
   uv_async_t* async;
   std::shared_ptr<CodeMap> code_map;
   CpuTime cpu_time;
-  std::unique_ptr<Sample> lastSample;
+  SampleBuffer last_samples;
   std::shared_ptr<LabelWrap> labels_;
   double frequency = 0;
   Nan::Global<v8::Array> samples;

--- a/bindings/test/profilers/cpu.test.cc
+++ b/bindings/test/profilers/cpu.test.cc
@@ -45,11 +45,16 @@ void test_samples(Tap& t) {
 
   // Make a synthetic sample to set as the "last sample"
   auto label_wrap = std::make_shared<dd::LabelWrap>(labels);
-  std::vector<uintptr_t> frames = {1234};
-  uint64_t cpu_time = 12345;
+  std::vector<uintptr_t> frames1 = {1234};
+  uint64_t cpu_time1 = 12345;
 
-  std::unique_ptr<dd::Sample> sample(
-    new dd::Sample(isolate, label_wrap, frames, cpu_time));
+  std::unique_ptr<dd::Sample> sample1(
+    new dd::Sample(isolate, label_wrap, frames1, cpu_time1));
+
+  std::vector<uintptr_t> frames2 = {5678};
+  uint64_t cpu_time2 = 56789;
+  std::unique_ptr<dd::Sample> sample2(
+    new dd::Sample(isolate, label_wrap, frames2, cpu_time2));
 
   auto record = std::make_shared<dd::CodeEventRecord>(
     1234, 0, 5678, 1, 2, "fnA");
@@ -58,14 +63,15 @@ void test_samples(Tap& t) {
   map->Clear();
   map->Add(1234, record);
 
-  cpu.SetLastSample(std::move(sample));
+  cpu.SetLastSample(std::move(sample1));
+  cpu.SetLastSample(std::move(sample2));
   cpu.ProcessSample();
 
-  t.equal(1U, cpu.GetSampleCount(),
+  t.equal(2U, cpu.GetSampleCount(),
     "has processed sample after capture/process");
 
   auto samples = cpu.GetSamples();
-  t.equal(1U, samples->Length(),
+  t.equal(2U, samples->Length(),
     "should have one processed sample in samples array");
 
   auto firstSample = Nan::Get(samples, 0).ToLocalChecked().As<v8::Object>();


### PR DESCRIPTION
If several samples are captured before symbolizer has a chance top run, then only the last one will be accounted for.
This change introduces a ring buffer (whose size is arbitrarily set to 100), that stores captured samples.
Symbolizer processes all samples present in the ring buffer instead of a single one.