### PR TITLE
Store cpu time per LabelSet in CpuProfile

### DIFF
--- a/ts/src/cpu-profiler.ts
+++ b/ts/src/cpu-profiler.ts
@@ -87,10 +87,14 @@ export default class CpuProfiler extends NativeCpuProfiler {
         targetNode = node;
       }
 
-      targetNode.cpuTime += sample.cpuTime;
-      targetNode.hitCount++;
-      if (sample.labels) {
-        targetNode.labelSets.push(sample.labels);
+      if (sample.labels && Object.keys(sample.labels).length > 0) {
+        targetNode.labelSets.push({
+          labels: sample.labels,
+          cpuTime: sample.cpuTime,
+        });
+      } else {
+        targetNode.cpuTime += sample.cpuTime;
+        targetNode.hitCount++;
       }
 
       targetNode = timeProfile.topDownRoot;

--- a/ts/src/profile-serializer.ts
+++ b/ts/src/profile-serializer.ts
@@ -366,25 +366,19 @@ export function serializeCpuProfile(
     entry: Entry<CpuProfileNode>,
     samples: perftools.profiles.Sample[]
   ) => {
-    for (const labelSet of entry.node.labelSets) {
+    for (const labelCpu of entry.node.labelSets) {
       const sample = new perftools.profiles.Sample({
         locationId: entry.stack,
-        value: [1, intervalNanos],
-        label: buildLabels(labelSet, stringTable),
+        value: [1, labelCpu.cpuTime],
+        label: buildLabels(labelCpu.labels, stringTable),
       });
 
       samples.push(sample);
     }
-
-    const unknownEntryCount = entry.node.hitCount - entry.node.labelSets.length;
-    if (unknownEntryCount > 0) {
+    if (entry.node.hitCount > 0) {
       const sample = new perftools.profiles.Sample({
         locationId: entry.stack,
-        value: [
-          unknownEntryCount,
-          entry.node.cpuTime,
-          // unknownEntryCount * intervalNanos,
-        ],
+        value: [entry.node.hitCount, entry.node.cpuTime],
       });
       samples.push(sample);
     }

--- a/ts/src/v8-types.ts
+++ b/ts/src/v8-types.ts
@@ -67,10 +67,15 @@ export interface LabelSet {
   [key: string]: string | number;
 }
 
+export interface LabelsCpu {
+  labels: LabelSet;
+  cpuTime: number;
+}
+
 export interface CpuProfileNode extends ProfileNode {
   hitCount: number;
   cpuTime: number;
-  labelSets: LabelSet[];
+  labelSets: LabelsCpu[];
 }
 
 export interface CpuProfileSample {


### PR DESCRIPTION
This change fixes several issues:
* Measured cpu time is not used for samples with labels when converted to CpuProfile: samples with labels are assigned the sampling period, which is incorrect since based on wall clock
* During conversion to CpuProfile, all samples are treaded as having labels (and thus are impacted by the previous issue). This is because when no labels are set, the empty object `{}` is stored in CpuProfiler.labels (by NativeCpuProfiler._exit in cpu.js), and this empty object is added to CpuProfileNode.labelSets.
* CPU time of samples without labels is incorrectly reported since all cpu time measured for a CpuProfileNode (with or without labels) is assigned to the samples without labels

To fix theses issues, following changes are made during conversion to CpuProfile:
* cpu time is recoded per LabelSet
* samples with empty object `{}` as labels are treated as not having labels (a better fix would be for cpu.js to store `null` when no labels)
* CpuProfileNode.cpuTime is only the aggregation of cpuTime of samples without labels