### PR TITLE
Remove mutex from cpu profiler

### DIFF
--- a/bindings/profilers/cpu.hh
+++ b/bindings/profilers/cpu.hh
@@ -3,7 +3,6 @@
 #include <cstdint>
 #include <memory>
 #include <atomic>
-#include <mutex>
 
 #include <nan.h>
 #include <uv.h>
@@ -90,7 +89,6 @@ class CpuProfiler : public Nan::ObjectWrap {
   std::shared_ptr<LabelWrap> labels_;
   double frequency = 0;
   Nan::Global<v8::Array> samples;
-  std::mutex mutex;
   uint64_t start_time;
   uv_sem_t sampler_thread_done;
   uv_thread_t sampler_thread;


### PR DESCRIPTION
SetLabels / CaptureSample / ProcessSamples are all executed by the javascript thread, and therefore no synchronization is needed.