### PR TITLE
Fix random CPU profiler crash during node shutdown

### DIFF
--- a/bindings/profilers/cpu.hh
+++ b/bindings/profilers/cpu.hh
@@ -97,7 +97,6 @@ class CpuProfiler : public Nan::ObjectWrap {
  public:
   CpuProfiler();
   ~CpuProfiler();
-  static CpuProfiler* New();
 
   // Disable copies and moves
   CpuProfiler(const CpuProfiler& other) = delete;
@@ -119,6 +118,7 @@ class CpuProfiler : public Nan::ObjectWrap {
   void SetLabels(v8::Local<v8::Value>);
   void Start(double hz);
   void Stop();
+  void StopAndWaitThread();
   uint32_t GetSampleCount();
   v8::Local<v8::Array> GetSamples();
   v8::Local<v8::Value> GetProfile();


### PR DESCRIPTION
Crashes were caused by SamplerThread calling `Isolate::RequestInterrupt` during Node shutdown.
Fix this by adding a cleanup hook with `node::AddEnvironmentCleanupHook` that stops the profiler upon node exit.