### PR TITLE
Recompute wall profiler sampling interval

### DIFF
--- a/ts/src/profile-serializer.ts
+++ b/ts/src/profile-serializer.ts
@@ -250,6 +250,16 @@ function createAllocationValueType(table: StringTable): ValueType {
   });
 }
 
+function computeTotalHitCount(root: TimeProfileNode): number {
+  return (
+    root.hitCount +
+    (root.children as TimeProfileNode[]).reduce(
+      (sum, node) => sum + computeTotalHitCount(node),
+      0
+    )
+  );
+}
+
 /**
  * Converts v8 time profile into into a profile proto.
  * (https://github.com/google/pprof/blob/master/proto/profile.proto)
@@ -259,9 +269,18 @@ function createAllocationValueType(table: StringTable): ValueType {
  */
 export function serializeTimeProfile(
   prof: TimeProfile,
-  intervalMicros: number,
+  intervalMicros?: number,
   sourceMapper?: SourceMapper
 ): Profile {
+  // If intervalMicros is not defined, recompute it from profile duration and total number of hits,
+  // since profile duration should be #hits x interval
+  // Moreover recomputing an average interval is more accurate, since in practice intervals between
+  // samples are larger than the requested sampling interval (eg. 12.5ms vs 10ms requested).
+  if (!intervalMicros) {
+    intervalMicros = Math.floor(
+      (prof.endTime - prof.startTime) / computeTotalHitCount(prof.topDownRoot)
+    );
+  }
   const intervalNanos = intervalMicros * 1000;
   const appendTimeEntryToSamples: AppendEntryToSamples<TimeProfileNode> = (
     entry: Entry<TimeProfileNode>,

--- a/ts/src/profile-serializer.ts
+++ b/ts/src/profile-serializer.ts
@@ -269,17 +269,21 @@ function computeTotalHitCount(root: TimeProfileNode): number {
  */
 export function serializeTimeProfile(
   prof: TimeProfile,
-  intervalMicros?: number,
-  sourceMapper?: SourceMapper
+  intervalMicros: number,
+  sourceMapper?: SourceMapper,
+  recomputeSamplingInterval = false
 ): Profile {
-  // If intervalMicros is not defined, recompute it from profile duration and total number of hits,
+  // If requested, recompute sampling interval it from profile duration and total number of hits,
   // since profile duration should be #hits x interval
-  // Moreover recomputing an average interval is more accurate, since in practice intervals between
+  // Recomputing an average interval is more accurate, since in practice intervals between
   // samples are larger than the requested sampling interval (eg. 12.5ms vs 10ms requested).
-  if (!intervalMicros) {
-    intervalMicros = Math.floor(
-      (prof.endTime - prof.startTime) / computeTotalHitCount(prof.topDownRoot)
-    );
+  if (recomputeSamplingInterval) {
+    const totalHitCount = computeTotalHitCount(prof.topDownRoot);
+    if (totalHitCount > 0) {
+      intervalMicros = Math.floor(
+        (prof.endTime - prof.startTime) / computeTotalHitCount(prof.topDownRoot)
+      );
+    }
   }
   const intervalNanos = intervalMicros * 1000;
   const appendTimeEntryToSamples: AppendEntryToSamples<TimeProfileNode> = (

--- a/ts/src/time-profiler.ts
+++ b/ts/src/time-profiler.ts
@@ -85,7 +85,7 @@ export function start(
     if (restart) {
       runName = start();
     }
-    return serializeTimeProfile(result, undefined, sourceMapper);
+    return serializeTimeProfile(result, intervalMicros, sourceMapper, true);
   }
 
   // For Node.js v16+, we want to start the next profile before we stop the
@@ -101,6 +101,6 @@ export function start(
       runName = nextRunName;
     }
     if (!restart) profiler.dispose();
-    return serializeTimeProfile(result, undefined, sourceMapper);
+    return serializeTimeProfile(result, intervalMicros, sourceMapper, true);
   }
 }

--- a/ts/src/time-profiler.ts
+++ b/ts/src/time-profiler.ts
@@ -85,7 +85,7 @@ export function start(
     if (restart) {
       runName = start();
     }
-    return serializeTimeProfile(result, intervalMicros, sourceMapper);
+    return serializeTimeProfile(result, undefined, sourceMapper);
   }
 
   // For Node.js v16+, we want to start the next profile before we stop the
@@ -101,6 +101,6 @@ export function start(
       runName = nextRunName;
     }
     if (!restart) profiler.dispose();
-    return serializeTimeProfile(result, intervalMicros, sourceMapper);
+    return serializeTimeProfile(result, undefined, sourceMapper);
   }
 }

--- a/ts/test/profiles-for-tests.ts
+++ b/ts/test/profiles-for-tests.ts
@@ -105,7 +105,7 @@ const timeRoot = {
 
 export const v8TimeProfile: TimeProfile = Object.freeze({
   startTime: 0,
-  endTime: 10 * 1000 * 1000,
+  endTime: 7 * 1000,
   topDownRoot: timeRoot,
 });
 
@@ -196,7 +196,7 @@ export const timeProfile = new Profile({
     'script1',
   ]),
   timeNanos: 0,
-  durationNanos: 10 * 1000 * 1000 * 1000,
+  durationNanos: 7 * 1000 * 1000,
   periodType: new ValueType({type: 3, unit: 4}),
   period: 1000000,
 });

--- a/ts/test/worker.ts
+++ b/ts/test/worker.ts
@@ -29,9 +29,9 @@ function getAndVerifyPresence(list: any[], id: number, zeroIndex = false) {
   return list[index];
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function getAndVerifyString(
   stringTable: StringTable,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   source: any,
   field: string
 ) {


### PR DESCRIPTION
The effective sampling interval of wall profiler is larger than the requested one. Eg. when requesting a 99Hz sampling rate (~10.1ms sampling interval), we observe an average sampling interval of ~12.5ms. This discrepancy leads to an underestimation of CPU consumption since samplesare weighted by the samping interval. To fix this discrepancy we recompute the average samping interval from profile duration and total number of hits, since profile duration should be #hits x mean interval.