### PR TITLE
Fix push when sample buffer is full

### DIFF
--- a/bindings/profilers/cpu.hh
+++ b/bindings/profilers/cpu.hh
@@ -46,7 +46,10 @@ public:
       {
         return;
       }
+      // overwrite buffer head
+      samples_[back_index_] = std::move(ptr);
       increment(back_index_);
+      // move buffer head
       front_index_ = back_index_;
     }
     else


### PR DESCRIPTION
Currently latest sample is dropped when buffer is full, therefore this bug does not occur.