### PR TITLE
Wall profiler constructor not maintained per-isolate

### DIFF
--- a/bindings/location.cc
+++ b/bindings/location.cc
@@ -3,21 +3,18 @@
 #include <node.h>
 
 #include "location.hh"
-#include "per-isolate-data.hh"
 
 namespace dd {
 
-Location::Location(v8::Isolate* isolate,
-                   std::shared_ptr<CodeEventRecord> code_event_record)
+Location::Location(std::shared_ptr<CodeEventRecord> code_event_record)
     : code_event_record(std::move(code_event_record)) {}
 
-Location* Location::New(v8::Isolate* isolate,
+Location* Location::New(PerIsolateData* per_isolate,
                         std::shared_ptr<CodeEventRecord> code_event_record) {
-  auto per_isolate = PerIsolateData::For(isolate);
   v8::Local<v8::Function> cons = Nan::New(per_isolate->LocationConstructor());
   auto inst = Nan::NewInstance(cons, 0, {}).ToLocalChecked();
 
-  auto location = new Location(isolate, std::move(code_event_record));
+  auto location = new Location(std::move(code_event_record));
   location->Wrap(inst);
   return location;
 }

--- a/bindings/location.hh
+++ b/bindings/location.hh
@@ -4,6 +4,7 @@
 #include <node_object_wrap.h>  // cppcheck-suppress missingIncludeSystem
 
 #include "code-event-record.hh"
+#include "per-isolate-data.hh"
 
 namespace dd {
 
@@ -12,10 +13,9 @@ class Location : public Nan::ObjectWrap {
   std::shared_ptr<CodeEventRecord> code_event_record;
 
  public:
-  explicit Location(v8::Isolate* isolate,
-                    std::shared_ptr<CodeEventRecord> code_event_record);
+  explicit Location(std::shared_ptr<CodeEventRecord> code_event_record);
 
-  static Location* New(v8::Isolate* isolate,
+  static Location* New(PerIsolateData* per_isolate,
                        std::shared_ptr<CodeEventRecord> code_event_record);
 
   std::shared_ptr<CodeEventRecord> GetCodeEventRecord();

--- a/bindings/per-isolate-data.cc
+++ b/bindings/per-isolate-data.cc
@@ -40,6 +40,10 @@ Nan::Global<v8::Function>& PerIsolateData::SampleConstructor() {
   return sample_constructor;
 }
 
+Nan::Global<v8::Function>& PerIsolateData::WallProfilerConstructor() {
+  return wall_profiler_constructor;
+}
+
 std::shared_ptr<HeapProfilerState>& PerIsolateData::GetHeapProfilerState() {
   return heap_profiler_state;
 }

--- a/bindings/per-isolate-data.hh
+++ b/bindings/per-isolate-data.hh
@@ -14,6 +14,7 @@ class PerIsolateData {
   Nan::Global<v8::Function> cpu_profiler_constructor;
   Nan::Global<v8::Function> location_constructor;
   Nan::Global<v8::Function> sample_constructor;
+  Nan::Global<v8::Function> wall_profiler_constructor;
   std::shared_ptr<HeapProfilerState> heap_profiler_state;
 
   PerIsolateData() {}
@@ -24,6 +25,7 @@ class PerIsolateData {
   Nan::Global<v8::Function>& CpuProfilerConstructor();
   Nan::Global<v8::Function>& LocationConstructor();
   Nan::Global<v8::Function>& SampleConstructor();
+  Nan::Global<v8::Function>& WallProfilerConstructor();
   std::shared_ptr<HeapProfilerState>& GetHeapProfilerState();
 };
 

--- a/bindings/sample.cc
+++ b/bindings/sample.cc
@@ -71,9 +71,10 @@ v8::Local<v8::Array> Sample::Symbolize(std::shared_ptr<CodeMap> code_map) {
                  std::front_inserter(records),
                  ToCodeEventRecord);
 
+  auto per_isolate = PerIsolateData::For(isolate);
   for (auto record : records) {
     if (record) {
-      auto location = Location::New(isolate, record);
+      auto location = Location::New(per_isolate, record);
       Nan::Set(locations, locations->Length(), location->handle()).Check();
     }
   }

--- a/bindings/test/location.test.cc
+++ b/bindings/test/location.test.cc
@@ -10,7 +10,8 @@ void test_location(Tap& t) {
       std::make_shared<dd::CodeEventRecord>(1234, 0, 5678, 1, 2, "a", "b", "c");
   record->SetScriptId(123);
 
-  auto obj = dd::Location::New(isolate, record)->handle();
+  auto obj =
+      dd::Location::New(dd::PerIsolateData::For(isolate), record)->handle();
 
   // Type helpers
   auto Get = [isolate](v8::Local<v8::Object> obj,

--- a/ts/test/test-worker-threads.ts
+++ b/ts/test/test-worker-threads.ts
@@ -8,10 +8,10 @@ const assert = require('assert');
 
 describe('Worker Threads', () => {
   // eslint-ignore-next-line prefer-array-callback
-  it('should work when propagated to a worker through -r flag', function () {
+  it('should work when propagated to workers through -r flag', function () {
     this.timeout(5000);
     return exec('node', ['./out/test/worker.js']).then(({stdout}) => {
-      assert.strictEqual(stdout, 'it works!\nit works!\n');
+      assert.strictEqual(stdout, 'it works!\nit works!\nit works!\n');
     });
   });
 });

--- a/ts/test/worker.ts
+++ b/ts/test/worker.ts
@@ -8,7 +8,11 @@ const assert = require('assert');
 const {hasOwnProperty} = Object.prototype;
 
 if (isMainThread) {
-  new Worker(__filename);
+  new Worker(__filename).on('exit', () => {
+    // Run a second worker after the first one exited to test for proper
+    // cleanup after first worker. This used to segfault.
+    new Worker(__filename);
+  });
 }
 
 function valueName(profile: Profile, vt: ValueType) {


### PR DESCRIPTION
Wall profiler's JS class' constructor was not maintained per-isolate but instead in a static. This caused a segfault in a node process using Worker API because every worker has its own isolate. If a new worker started up after the worker (and isolate) to which the current value of the constructor handle belonged, the handle would attempt to release its old value, which at that time is a dangling pointer, causing a segfault.

* I modified the `worker.ts` test to run two workers one after the other, the second launching after the first one was destroyed. This caused a segfault in 100% of the attempted (many) runs. 
* After confirming that we have a reproducer in the test, a fix was devised to use the existing `PerIsolateData` data structure and have it also manage this class' constructor. After the fix, there's no longer a segfault in the worker test.
* Additionally, we observed that `PerIsolateData` needs to be guarded against multithreaded access, so I added a mutex to guard it.
* Finally, to reduce the overhead of the mutex when constructing locations belonging in samples of the experimental CPU profiler, I moved the lookup of per isolate data outside of a location-constructing loop.