### PR TITLE
Add a gatekeeper job to easily make PRs fail

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,3 +34,12 @@ jobs:
           echo "::set-output name=json::$content"
       - run: npm version --no-git-tag-version ${{ fromJson(steps.pkg.outputs.json).version }}-$(git rev-parse --short HEAD)+${{ github.run_id }}.${{ github.run_attempt }}
       - run: npm publish --tag dev
+
+  build-successful:
+    if: always()
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Determine if everything is passing
+      run: exit 1
+      if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}


### PR DESCRIPTION
The end goal is to disallow merging pull requests that have a failed check. Trouble is that you need to specify manually each check that is required for merging in github UI and in the case of a matrix job such as build, this represents around 20 different checks. The solution is to create a new job that depends on the other jobs and check the status of this job (but there are some [additional](https://github.com/orgs/community/discussions/26733) [caveats](https://github.com/orgs/community/discussions/26822)).