### PR TITLE
Make package installable from git branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,14 +10,8 @@ commands:
       - restore_cache:
           key: yarn-{{ .Environment.CIRCLE_JOB }}-{{ checksum "package.json" }}
       - run:
-          name: Hide gyp file
-          command: mv binding.gyp binding.gyp.bak
-      - run:
           name: Install dependencies
           command: yarn install --ignore-engines
-      - run:
-          name: Restore gyp file
-          command: mv binding.gyp.bak binding.gyp
       - save_cache:
           key: yarn-{{ .Environment.CIRCLE_JOB }}-{{ checksum "package.json" }}
           paths:
@@ -82,32 +76,24 @@ prebuild-linux-base: &prebuild-linux-base
 jobs:
   node-bench-sirun: *node-bench-sirun-base
 
-  linux-x64-18:
+  linux-x64:
     <<: *prebuild-linux-base
     docker:
       # from node:12.0.0 on 2021-08-30
       - image: node@sha256:c88ef4f7ca8d52ed50366d821e104d029f43e8686120a29541ce0371f333453f
     environment:
       - ARCH=x64
-      - NODE_VERSIONS=15 - 18
-
-  linux-x64-12:
-    <<: *prebuild-linux-base
-    environment:
-      - ARCH=x64
-      - NODE_VERSIONS=12 - 14
+      - NODE_VERSIONS=12 - 18
 
 workflows:
   version: 2
   build:
     jobs: &jobs
       # Linux x64
-      - linux-x64-18
-      - linux-x64-12
+      - linux-x64
       - node-bench-sirun:
           requires:
-            - linux-x64-18
-            - linux-x64-12
+            - linux-x64
           matrix:
             parameters:
               node-version: ["12-buster", "14", "16", "18"]

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "format": "clang-format --style file -i --glob='bindings/**/*.{h,hh,cpp,cc}'",
     "prebuild": "node scripts/prebuild.js",
     "prebuilds": "node scripts/prebuilds.js",
-    "prepare": "npm run compile",
+    "prepare": "npm run compile && npm run rebuild",
     "pretest": "npm run compile && npm run rebuild"
   },
   "author": {


### PR DESCRIPTION
This makes pprof-nodejs installable from a git branch: npm install DataDog/pprof-nodejs#some_branch

This works because npm invokes prepare script when fetching git dependencies and in that case also install package dev dependencies. This does not work with yarn though...