### PR TITLE
Revert "Fix sourcemap lookup when line numbers are enabled (#81)"

### DIFF
--- a/ts/src/sourcemapper/sourcemapper.ts
+++ b/ts/src/sourcemapper/sourcemapper.ts
@@ -212,21 +212,13 @@ export class SourceMapper {
       return location;
     }
 
-    const generatedPos = {
-      line: location.line,
-      column: location.column,
-      bias: sourceMap.SourceMapConsumer.LEAST_UPPER_BOUND,
-    };
+    const generatedPos = {line: location.line, column: location.column};
 
     // TODO: Determine how to remove the explicit cast here.
     const consumer: sourceMap.SourceMapConsumer =
       entry.mapConsumer as {} as sourceMap.SourceMapConsumer;
 
-    let pos = consumer.originalPositionFor(generatedPos);
-    if (pos.source === null) {
-      generatedPos.bias = sourceMap.SourceMapConsumer.GREATEST_LOWER_BOUND;
-      pos = consumer.originalPositionFor(generatedPos);
-    }
+    const pos = consumer.originalPositionFor(generatedPos);
     if (pos.source === null) {
       return location;
     }


### PR DESCRIPTION
This reverts commit cfebbb3c94fb700e286f919ead74dd0bab0dff81.
This commit resulted in failure to get original function name back for source maps generated by webpack.