### PR TITLE
Improve source maps

### DIFF
--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -23,6 +23,7 @@ export {AllocationProfileNode, TimeProfileNode, ProfileNode} from './v8-types';
 
 export {encode, encodeSync} from './profile-encoder';
 export {SourceMapper} from './sourcemapper/sourcemapper';
+export {setLogger} from './logger';
 
 export const CpuProfiler = cpuProfiler;
 

--- a/ts/src/logger.ts
+++ b/ts/src/logger.ts
@@ -1,0 +1,41 @@
+export interface Logger {
+  error(...args: Array<{}>): void;
+  trace(...args: Array<{}>): void;
+  debug(...args: Array<{}>): void;
+  info(...args: Array<{}>): void;
+  warn(...args: Array<{}>): void;
+  fatal(...args: Array<{}>): void;
+}
+
+export class NullLogger implements Logger {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  info(...args: Array<{}>): void {
+    return;
+  }
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  error(...args: Array<{}>): void {
+    return;
+  }
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  trace(...args: Array<{}>): void {
+    return;
+  }
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  warn(...args: Array<{}>): void {
+    return;
+  }
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  fatal(...args: Array<{}>): void {
+    return;
+  }
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  debug(...args: Array<{}>): void {
+    return;
+  }
+}
+
+export let logger = new NullLogger();
+
+export function setLogger(newLogger: Logger) {
+  logger = newLogger;
+}

--- a/ts/test/profiles-for-tests.ts
+++ b/ts/test/profiles-for-tests.ts
@@ -851,7 +851,9 @@ mapBaz.addMapping({
 });
 
 fs.writeFileSync(path.join(mapDirPath, 'foo.js.map'), mapFoo.toString());
+fs.writeFileSync(path.join(mapDirPath, 'foo.js'), '');
 fs.writeFileSync(path.join(mapDirPath, 'baz.js.map'), mapBaz.toString());
+fs.writeFileSync(path.join(mapDirPath, 'baz.js'), '');
 
 const heapGeneratedLeaf1 = {
   name: 'foo2',

--- a/ts/test/profiles-for-tests.ts
+++ b/ts/test/profiles-for-tests.ts
@@ -17,18 +17,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as tmp from 'tmp';
-
-// Apparently the source-map module feature-detects the browser by checking
-// if the fetch function exists. Because it now exists in Node.js v18, the
-// source-map module thinks it's running in a browser and doesn't work.
-const desc = Object.getOwnPropertyDescriptor(globalThis, 'fetch');
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-delete globalThis.fetch;
 import {SourceMapGenerator} from 'source-map';
-if (desc) {
-  Object.defineProperty(globalThis, 'fetch', desc);
-}
 
 import {Function, Location, Profile, Sample, ValueType} from 'pprof-format';
 


### PR DESCRIPTION
* Allow to inject logger in profiler
* Use logger to debug source maps
* Work around faulty file path in webpack sourcemaps:
    With nextjs/webpack, when there are subdirectories in `pages` directory, the generated source maps do not reference correctly the generated files in their `file` property.
    For example if the generated file / source maps have paths:
    <root>/pages/sub/foo.js(.map)
    foo.js.map will have ../pages/sub/foo.js as `file` property instead of ../../pages/sub/foo.js
    To workaround this, check first if file referenced in `file` property exists and if it does not, check if generated file exists alongside the source map file.