### PR TITLE
Fix bug in profiler map

### DIFF
--- a/bindings/profilers/wall.cc
+++ b/bindings/profilers/wall.cc
@@ -107,6 +107,7 @@ class ProtectedProfilerMap {
 
     if (!init_) {
       profilers_.store(new ProfilerMap(), std::memory_order_release);
+      init_ = true;
     }
 
     auto currProfilers = profilers_.load(std::memory_order_acquire);
@@ -138,7 +139,6 @@ class ProtectedProfilerMap {
 using ProfilerMap = std::unordered_map<Isolate*, WallProfiler*>;
 
 static ProtectedProfilerMap g_profilers;
-static std::mutex g_profilers_update_mtx;
 
 namespace {
 

--- a/ts/src/profile-serializer.ts
+++ b/ts/src/profile-serializer.ts
@@ -272,10 +272,7 @@ export function serializeTimeProfile(
     if (totalHitCount > 0) {
       intervalMicros = Math.min(
         Math.max(
-          Math.floor(
-            (prof.endTime - prof.startTime) /
-              computeTotalHitCount(prof.topDownRoot)
-          ),
+          Math.floor((prof.endTime - prof.startTime) / totalHitCount),
           intervalMicros
         ),
         2 * intervalMicros

--- a/ts/test/test-worker-threads.ts
+++ b/ts/test/test-worker-threads.ts
@@ -4,14 +4,11 @@ import {promisify} from 'util';
 
 const exec = promisify(execFile);
 
-const assert = require('assert');
-
 describe('Worker Threads', () => {
   // eslint-ignore-next-line prefer-array-callback
   it('should work when propagated to workers through -r flag', function () {
-    this.timeout(5000);
-    return exec('node', ['./out/test/worker.js']).then(({stdout}) => {
-      assert.strictEqual(stdout, 'it works!\nit works!\nit works!\n');
-    });
+    this.timeout(10000);
+    const nbWorkers = 4;
+    return exec('node', ['./out/test/worker.js', String(nbWorkers)]);
   });
 });


### PR DESCRIPTION
`init_` was never set to true leading to reinitialization of the whole map each time a profiler was added/removed.