### PR TITLE
Workaround v8 bug

### DIFF
--- a/bindings/profilers/wall.cc
+++ b/bindings/profilers/wall.cc
@@ -489,8 +489,11 @@ Result WallProfiler::StartImpl() {
 }
 
 std::string WallProfiler::StartInternal() {
+  // Reuse the same names for the profiles because strings used for profile
+  // names are not released until v8::CpuProfiler object is destroyed.
+  // https://github.com/nodejs/node/blob/b53c51995380b1f8d642297d848cab6010d2909c/deps/v8/src/profiler/profile-generator.h#L516
   char buf[128];
-  snprintf(buf, sizeof(buf), "pprof-%" PRId64, profileIdx_++);
+  snprintf(buf, sizeof(buf), "pprof-%" PRId64, (profileIdx_++) % 2);
   v8::Local<v8::String> title = Nan::New<String>(buf).ToLocalChecked();
   cpuProfiler_->StartProfiling(
       title,

--- a/bindings/profilers/wall.hh
+++ b/bindings/profilers/wall.hh
@@ -36,6 +36,9 @@ struct Result {
 };
 
 class WallProfiler : public Nan::ObjectWrap {
+ public:
+  enum class CollectionMode { kNoCollect, kPassThrough, kCollectContexts };
+
  private:
   enum Fields { kSampleCount, kFieldCount };
 
@@ -52,13 +55,17 @@ class WallProfiler : public Nan::ObjectWrap {
   ContextPtr context1_;
   ContextPtr context2_;
   std::atomic<ContextPtr*> curContext_;
-  std::atomic<bool> collectSamples_;
+
+  std::atomic<CollectionMode> collectionMode_;
+  std::atomic<uint64_t> noCollectCallCount_;
   std::string profileId_;
-  int64_t profileIdx_ = 0;
+  uint64_t profileIdx_ = 0;
   bool includeLines_ = false;
   bool withContexts_ = false;
   bool started_ = false;
-  bool v8ProfilerStuckEventLoopDetected_ = false;
+  bool workaroundV8Bug_;
+  bool detectV8Bug_;
+  int v8ProfilerStuckEventLoopDetected_ = 0;
 
   uint32_t* fields_;
   v8::Global<v8::Uint32Array> jsArray_;
@@ -82,6 +89,8 @@ class WallProfiler : public Nan::ObjectWrap {
   ContextsByNode GetContextsByNode(v8::CpuProfile* profile,
                                    ContextBuffer& contexts);
 
+  bool waitForSignal(uint64_t targetCallCount = 0);
+
  public:
   /**
    * @param samplingPeriodMicros sampling interval, in microseconds
@@ -93,7 +102,8 @@ class WallProfiler : public Nan::ObjectWrap {
   explicit WallProfiler(int samplingPeriodMicros,
                         int durationMicros,
                         bool includeLines,
-                        bool withContexts);
+                        bool withContexts,
+                        bool workaroundV8bug);
 
   v8::Local<v8::Value> GetContext(v8::Isolate*);
   void SetContext(v8::Isolate*, v8::Local<v8::Value>);
@@ -103,13 +113,16 @@ class WallProfiler : public Nan::ObjectWrap {
   Result StopImpl(bool restart, v8::Local<v8::Value>& profile);
   Result StopImplOld(bool restart, v8::Local<v8::Value>& profile);
 
-  bool collectSampleAllowed() const {
-    bool res = collectSamples_.load(std::memory_order_relaxed);
+  CollectionMode collectionMode() {
+    auto res = collectionMode_.load(std::memory_order_relaxed);
+    if (res == CollectionMode::kNoCollect) {
+      noCollectCallCount_.fetch_add(1, std::memory_order_relaxed);
+    }
     std::atomic_signal_fence(std::memory_order_acquire);
     return res;
   }
 
-  bool v8ProfilerStuckEventLoopDetected() const {
+  int v8ProfilerStuckEventLoopDetected() const {
     return v8ProfilerStuckEventLoopDetected_;
   }
 

--- a/bindings/profilers/wall.hh
+++ b/bindings/profilers/wall.hh
@@ -58,6 +58,7 @@ class WallProfiler : public Nan::ObjectWrap {
   bool includeLines_ = false;
   bool withContexts_ = false;
   bool started_ = false;
+  bool v8ProfilerStuckEventLoopDetected_ = false;
 
   uint32_t* fields_;
   v8::Global<v8::Uint32Array> jsArray_;
@@ -108,9 +109,14 @@ class WallProfiler : public Nan::ObjectWrap {
     return res;
   }
 
+  bool v8ProfilerStuckEventLoopDetected() const {
+    return v8ProfilerStuckEventLoopDetected_;
+  }
+
   static NAN_METHOD(New);
   static NAN_METHOD(Start);
   static NAN_METHOD(Stop);
+  static NAN_METHOD(V8ProfilerStuckEventLoopDetected);
   static NAN_MODULE_INIT(Init);
   static NAN_GETTER(GetContext);
   static NAN_SETTER(SetContext);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@datadog/pprof",
-  "version": "3.0.0-pre",
+  "version": "4.0.0-pre",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@datadog/pprof",
-      "version": "3.0.0-pre",
+      "version": "4.0.0-pre",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -35,6 +35,8 @@ export const time = {
   stop: timeProfiler.stop,
   setContext: timeProfiler.setContext,
   isStarted: timeProfiler.isStarted,
+  v8ProfilerStuckEventLoopDetected:
+    timeProfiler.v8ProfilerStuckEventLoopDetected,
   getState: timeProfiler.getState,
   constants: timeProfiler.constants,
 };

--- a/ts/src/time-profiler.ts
+++ b/ts/src/time-profiler.ts
@@ -35,7 +35,7 @@ type Milliseconds = number;
 let gProfiler: InstanceType<typeof TimeProfiler> | undefined;
 let gSourceMapper: SourceMapper | undefined;
 let gIntervalMicros: Microseconds;
-let gV8ProfilerStuckEventLoopDetected = false;
+let gV8ProfilerStuckEventLoopDetected = 0;
 
 /** Make sure to stop profiler before node shuts down, otherwise profiling
  * signal might cause a crash if it occurs during shutdown */
@@ -58,6 +58,7 @@ export interface TimeProfilerOptions {
    */
   lineNumbers?: boolean;
   withContexts?: boolean;
+  workaroundV8Bug?: boolean;
 }
 
 export async function profile({
@@ -66,6 +67,7 @@ export async function profile({
   sourceMapper,
   lineNumbers = false,
   withContexts = false,
+  workaroundV8Bug = true,
 }: TimeProfilerOptions) {
   start({
     intervalMicros,
@@ -73,6 +75,7 @@ export async function profile({
     sourceMapper,
     lineNumbers,
     withContexts,
+    workaroundV8Bug,
   });
   await delay(durationMillis);
   return stop();
@@ -85,6 +88,7 @@ export function start({
   sourceMapper,
   lineNumbers = false,
   withContexts = false,
+  workaroundV8Bug = true,
 }: TimeProfilerOptions) {
   if (gProfiler) {
     throw new Error('Wall profiler is already started');
@@ -94,11 +98,12 @@ export function start({
     intervalMicros,
     durationMillis * 1000,
     lineNumbers,
-    withContexts
+    withContexts,
+    workaroundV8Bug
   );
   gSourceMapper = sourceMapper;
   gIntervalMicros = intervalMicros;
-  gV8ProfilerStuckEventLoopDetected = false;
+  gV8ProfilerStuckEventLoopDetected = 0;
   gProfiler.start();
 }
 
@@ -111,15 +116,18 @@ export function stop(
   }
 
   const profile = gProfiler.stop(restart);
-  if (restart && gProfiler.v8ProfilerStuckEventLoopDetected()) {
+  if (restart) {
+    gV8ProfilerStuckEventLoopDetected =
+      gProfiler.v8ProfilerStuckEventLoopDetected();
     // Workaround for v8 bug, where profiler event processor thread is stuck in
     // a loop eating 100% CPU, leading to empty profiles.
     // Fully stop and restart the profiler to reset the profile to a valid state.
-    gProfiler.stop(false);
-    gProfiler.start();
-    gV8ProfilerStuckEventLoopDetected = true;
+    if (gV8ProfilerStuckEventLoopDetected > 0) {
+      gProfiler.stop(false);
+      gProfiler.start();
+    }
   } else {
-    gV8ProfilerStuckEventLoopDetected = false;
+    gV8ProfilerStuckEventLoopDetected = 0;
   }
 
   const serialized_profile = serializeTimeProfile(
@@ -154,6 +162,7 @@ export function isStarted() {
   return !!gProfiler;
 }
 
+// Return 0 if no issue detected, 1 if possible issue, 2 if issue detected for certain
 export function v8ProfilerStuckEventLoopDetected() {
   return gV8ProfilerStuckEventLoopDetected;
 }

--- a/ts/test/test-time-profiler.ts
+++ b/ts/test/test-time-profiler.ts
@@ -322,6 +322,7 @@ describe('Time Profiler', () => {
     const timeProfilerStub = {
       start: sinon.stub(),
       stop: sinon.stub().returns(v8TimeProfile),
+      v8ProfilerStuckEventLoopDetected: sinon.stub().returns(false),
     };
 
     before(() => {
@@ -357,6 +358,7 @@ describe('Time Profiler', () => {
       timeProfilerStub.stop.resetHistory();
 
       assert.deepEqual(timeProfile, time.stop(true));
+      assert(!time.v8ProfilerStuckEventLoopDetected(), 'v8 bug detected');
 
       sinon.assert.notCalled(timeProfilerStub.start);
       sinon.assert.calledOnce(timeProfilerStub.stop);
@@ -366,6 +368,44 @@ describe('Time Profiler', () => {
 
       assert.deepEqual(timeProfile, time.stop());
 
+      sinon.assert.notCalled(timeProfilerStub.start);
+      sinon.assert.calledOnce(timeProfilerStub.stop);
+    });
+  });
+
+  describe('v8BugWorkaround (w/ stubs)', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const sinonStubs: Array<sinon.SinonStub<any, any>> = [];
+    const timeProfilerStub = {
+      start: sinon.stub(),
+      stop: sinon.stub().returns(v8TimeProfile),
+      v8ProfilerStuckEventLoopDetected: sinon.stub().returns(true),
+    };
+
+    before(() => {
+      sinonStubs.push(
+        sinon.stub(v8TimeProfiler, 'TimeProfiler').returns(timeProfilerStub)
+      );
+      sinonStubs.push(sinon.stub(Date, 'now').returns(0));
+    });
+
+    after(() => {
+      sinonStubs.forEach(stub => {
+        stub.restore();
+      });
+    });
+
+    it('should reset profiler when empty profile is returned and restart is requested', () => {
+      time.start(PROFILE_OPTIONS);
+      time.stop(true);
+      sinon.assert.calledTwice(timeProfilerStub.start);
+      sinon.assert.calledTwice(timeProfilerStub.stop);
+
+      assert(time.v8ProfilerStuckEventLoopDetected(), 'v8 bug not detected');
+      timeProfilerStub.start.resetHistory();
+      timeProfilerStub.stop.resetHistory();
+
+      time.stop(false);
       sinon.assert.notCalled(timeProfilerStub.start);
       sinon.assert.calledOnce(timeProfilerStub.stop);
     });

--- a/ts/test/test-time-profiler.ts
+++ b/ts/test/test-time-profiler.ts
@@ -322,7 +322,7 @@ describe('Time Profiler', () => {
     const timeProfilerStub = {
       start: sinon.stub(),
       stop: sinon.stub().returns(v8TimeProfile),
-      v8ProfilerStuckEventLoopDetected: sinon.stub().returns(false),
+      v8ProfilerStuckEventLoopDetected: sinon.stub().returns(0),
     };
 
     before(() => {
@@ -358,7 +358,11 @@ describe('Time Profiler', () => {
       timeProfilerStub.stop.resetHistory();
 
       assert.deepEqual(timeProfile, time.stop(true));
-      assert(!time.v8ProfilerStuckEventLoopDetected(), 'v8 bug detected');
+      assert.equal(
+        time.v8ProfilerStuckEventLoopDetected(),
+        0,
+        'v8 bug detected'
+      );
 
       sinon.assert.notCalled(timeProfilerStub.start);
       sinon.assert.calledOnce(timeProfilerStub.stop);
@@ -379,7 +383,7 @@ describe('Time Profiler', () => {
     const timeProfilerStub = {
       start: sinon.stub(),
       stop: sinon.stub().returns(v8TimeProfile),
-      v8ProfilerStuckEventLoopDetected: sinon.stub().returns(true),
+      v8ProfilerStuckEventLoopDetected: sinon.stub().returns(2),
     };
 
     before(() => {
@@ -401,7 +405,11 @@ describe('Time Profiler', () => {
       sinon.assert.calledTwice(timeProfilerStub.start);
       sinon.assert.calledTwice(timeProfilerStub.stop);
 
-      assert(time.v8ProfilerStuckEventLoopDetected(), 'v8 bug not detected');
+      assert.equal(
+        time.v8ProfilerStuckEventLoopDetected(),
+        2,
+        'v8 bug not detected'
+      );
       timeProfilerStub.start.resetHistory();
       timeProfilerStub.stop.resetHistory();
 


### PR DESCRIPTION
v8 profiler event processor thread sometimes get stuck in a loop eating 100% CPU, leading to empty profiles.
This pull-request tries to accomplish goals:
* Make the bug less likely to happen by waiting for profiler signal before and after starting a new profile
* Detect if the bug has occurred (by checking for profiles with no hits or no non-ticks samples), and in that case fully stop and restart the profiler to reset the profile to a valid state.