### PR TITLE
Target ES2020 language

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,8 +3,7 @@
   "compilerOptions": {
     "rootDir": "ts",
     "outDir": "out",
-    "lib": [ "es2020" ],
-    "target": "es2019",
+    "target": "es2020",
     "esModuleInterop": true,
   },
   "include": [


### PR DESCRIPTION
**What does this PR do?**:
Upgrades TypeScript compiler settings to target ES2020. We already used ES2020 as the `lib` but were stuck on ES2019 as the `target`.

**Motivation**:
I'd like to use a bigint literal in a test soon. [dd-trace-js](https://github.com/DataDog/dd-trace-js/blob/master/.eslintrc.json#L3) also uses ES2020. It's a good choice for Node 14 and above.

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.


