### PR TITLE
Accept bigints as label values

### DIFF
--- a/ts/src/profile-serializer.ts
+++ b/ts/src/profile-serializer.ts
@@ -17,6 +17,7 @@
 import {
   Function,
   Label,
+  LabelInput,
   Line,
   Location,
   Profile,
@@ -334,18 +335,21 @@ function buildLabels(labelSet: object, stringTable: StringTable): Label[] {
   const labels: Label[] = [];
 
   for (const [key, value] of Object.entries(labelSet)) {
-    if (typeof value === 'number' || typeof value === 'string') {
-      const label = new Label({
-        key: stringTable.dedup(key),
-        num: typeof value === 'number' ? value : undefined,
-        str:
-          typeof value === 'string'
-            ? stringTable.dedup(value as string)
-            : undefined,
-      });
-
-      labels.push(label);
+    const labelInput: LabelInput = {
+      key: stringTable.dedup(key),
+    };
+    switch (typeof value) {
+      case 'string':
+        labelInput.str = stringTable.dedup(value);
+        break;
+      case 'number':
+      case 'bigint':
+        labelInput.num = value;
+        break;
+      default:
+        continue;
     }
+    labels.push(new Label(labelInput));
   }
 
   return labels;


### PR DESCRIPTION
**What does this PR do?**:
Makes the profile serializer start accepting (instead of discarding) sample labels whose values are bigints.

**Motivation**:
pprof-format handles bigint values just fine, yet the profile serializer was only accepting strings and numbers, not bigints. We need bigints to emit `end_timestamp_ns` in timelines.

**How to test the change?**:
I've been successfully using this for some time with my timelines prototype.

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

