### PR TITLE
Emit sample timestamps

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -48,5 +48,17 @@
                 ]
             }
         ]
-    ]
+    ],
+    "target_defaults": {
+        "conditions": [
+            [
+                'OS == "win"',
+                {
+                    "defines": [
+                        "NOMINMAX"
+                    ]
+                }
+            ]
+        ]
+    }
 }

--- a/bindings/profilers/wall.cc
+++ b/bindings/profilers/wall.cc
@@ -53,11 +53,10 @@ static int64_t Now() {
 #endif
 
 using namespace v8;
-using namespace std::chrono;
 
 namespace dd {
 // Maximum number of rounds in the GetV8ToEpochOffset
-static int MAX_EPOCH_OFFSET_ATTEMPTS = 20;
+static constexpr int MAX_EPOCH_OFFSET_ATTEMPTS = 20;
 
 int getTotalHitCount(const v8::CpuProfileNode* node, bool* noHitLeaf) {
   int count = node->GetHitCount();
@@ -298,6 +297,7 @@ static int64_t midpoint(int64_t x, int64_t y) {
 }
 
 static int64_t GetV8ToEpochOffset() {
+  using namespace std::chrono;
   // Make a best effort to capture the difference between UNIX epoch and the V8
   // profiling timer as precisely as possible. Will make at most 20 attempts to
   // capture the epoch time within the same V8 microsecond and use the one with

--- a/bindings/profilers/wall.cc
+++ b/bindings/profilers/wall.cc
@@ -50,6 +50,8 @@ static int64_t Now() {
 static int64_t Now() {
   return 0;
 };
+// a predefined "max" macro on _WIN32 clashes with std::numeric_limits::max()
+#undef max
 #endif
 
 using namespace v8;

--- a/bindings/profilers/wall.cc
+++ b/bindings/profilers/wall.cc
@@ -50,8 +50,6 @@ static int64_t Now() {
 static int64_t Now() {
   return 0;
 };
-// a predefined "max" macro on _WIN32 clashes with std::numeric_limits::max()
-#undef max
 #endif
 
 using namespace v8;

--- a/ts/src/profile-serializer.ts
+++ b/ts/src/profile-serializer.ts
@@ -37,6 +37,7 @@ import {
   ProfileNode,
   TimeProfile,
   TimeProfileNode,
+  TimeProfileNodeContext,
 } from './v8-types';
 
 /**
@@ -260,7 +261,7 @@ export function serializeTimeProfile(
   intervalMicros: number,
   sourceMapper?: SourceMapper,
   recomputeSamplingInterval = false,
-  generateLabels?: (context: object) => LabelSet
+  generateLabels?: (context: TimeProfileNodeContext) => LabelSet
 ): Profile {
   // If requested, recompute sampling interval from profile duration and total number of hits,
   // since profile duration should be #hits x interval.
@@ -287,7 +288,7 @@ export function serializeTimeProfile(
   ) => {
     let unlabelledHits = entry.node.hitCount;
     for (const context of entry.node.contexts || []) {
-      const labels = generateLabels ? generateLabels(context) : context;
+      const labels = generateLabels ? generateLabels(context) : context.context;
       if (Object.keys(labels).length > 0) {
         const sample = new Sample({
           locationId: entry.stack,

--- a/ts/src/time-profiler.ts
+++ b/ts/src/time-profiler.ts
@@ -22,7 +22,7 @@ import {
   TimeProfiler,
   constants as profilerConstants,
 } from './time-profiler-bindings';
-import {LabelSet} from './v8-types';
+import {LabelSet, TimeProfileNodeContext} from './v8-types';
 
 const {kSampleCount} = profilerConstants;
 
@@ -109,7 +109,7 @@ export function start({
 
 export function stop(
   restart = false,
-  generateLabels?: (context: object) => LabelSet
+  generateLabels?: (context: TimeProfileNodeContext) => LabelSet
 ) {
   if (!gProfiler) {
     throw new Error('Wall profiler is not started');

--- a/ts/src/v8-types.ts
+++ b/ts/src/v8-types.ts
@@ -34,9 +34,14 @@ export interface ProfileNode {
   children: ProfileNode[];
 }
 
+export interface TimeProfileNodeContext {
+  context: object;
+  timestamp: bigint; // end of sample taking; in microseconds since epoch
+}
+
 export interface TimeProfileNode extends ProfileNode {
   hitCount: number;
-  contexts?: object[];
+  contexts?: TimeProfileNodeContext[];
 }
 
 export interface AllocationProfileNode extends ProfileNode {

--- a/ts/test/profiles-for-tests.ts
+++ b/ts/test/profiles-for-tests.ts
@@ -1148,10 +1148,12 @@ export const labelEncodingProfile = {
         children: [],
         contexts: [
           {
-            someStr: 'foo',
-            someNum: 42,
-            someBigint: 18446744073709551557n,
-            ignored: {},
+            context: {
+              someStr: 'foo',
+              someNum: 42,
+              someBigint: 18446744073709551557n,
+              ignored: {},
+            },
           },
         ],
       },


### PR DESCRIPTION
**What does this PR do?**:
Adds a timestamp to the sample context objects exposed to JS. Previously, whatever was set with `context` setter on the profiler would be returned as the context object to `generateLabels` in the serializer. This is now changed, and instead an object is returned with structure `{ context: theContextObject, timestamp: epochTsMicros }` where `theContextObject` is the object set as the label context, and `epochTsMicros` is a bigint value, a number of microseconds since UNIX epoch marking the end timestamp of capturing the sample.

**Motivation**:
This will allow us to emit `end_timestamp_ns` label from the wall profiler in dd-trace, making it possible to visualize the time of sampling on timelines.

**Additional Notes**:
This PR is currently based on #132 not out of particular necessity, but because I need both functionality for timelines. Once #132 is merged, this PR will get rebased on main.

**How to test the change?**:
Existing unit tests have been modified to accommodate the changes and test the validity of generated timestamps.

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.