### PR TITLE
v4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/pprof",
-  "version": "4.0.0-pre",
+  "version": "4.0.0",
   "description": "pprof support for Node.js",
   "repository": "datadog/pprof-nodejs",
   "main": "out/src/index.js",


### PR DESCRIPTION
**What does this PR do?**:
Finalizes v4.0.0 for release. Datadog's pprof-nodejs now:
* drops support for Node 12 (minimum supported Node version is now 14), (#128)
* targets ES2020 language (previously: ES2019), (#131)
* handles reentrancy in NearHeapLimitCallback (#130), 
* supports bigints as label values in pprof serializer (#132), and
* emits epoch-based microseconds stamps on wall samples (#133)

**Motivation**:
We need to make a pprof-nodejs release so we can start using the new features in dd-trace

**How to test the change?**:
Usual `npm run test`. #132 and #133 have their own additions to unit tests.

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
