### PR TITLE
Explicitly add node-gyp version that doesn't rely on Pyhon distutils

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "delay": "^5.0.0",
+    "node-gyp": ">=10.0.1",
     "node-gyp-build": "<4.0",
     "p-limit": "^3.1.0",
     "pprof-format": "^2.0.7",


### PR DESCRIPTION
**What does this PR do?**:
Add explicit node-gyp dependency at version that doesn't rely on Python distutils anymore.

**Motivation**:
CI fails on macOS 'cause it likely gives us version of Python that no longer has distutils.
See: https://github.com/nodejs/node-gyp/issues/2869
See: https://github.com/DataDog/dd-native-iast-taint-tracking-js/pull/93

**How to test the change?**:
If it passes CI, it works.

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
