### PR TITLE
Avoid OOM abort in worker thread

### DIFF
--- a/ts/src/heap-profiler-bindings.ts
+++ b/ts/src/heap-profiler-bindings.ts
@@ -49,7 +49,8 @@ export function monitorOutOfMemory(
   dumpHeapProfileOnSdterr: boolean,
   exportCommand: Array<String> | undefined,
   callback: NearHeapLimitCallback | undefined,
-  callbackMode: number
+  callbackMode: number,
+  isMainThread: boolean
 ) {
   profiler.heapProfiler.monitorOutOfMemory(
     heapLimitExtensionSize,
@@ -57,6 +58,7 @@ export function monitorOutOfMemory(
     dumpHeapProfileOnSdterr,
     exportCommand,
     callback,
-    callbackMode
+    callbackMode,
+    isMainThread
   );
 }

--- a/ts/src/heap-profiler.ts
+++ b/ts/src/heap-profiler.ts
@@ -25,6 +25,7 @@ import {
 import {serializeHeapProfile} from './profile-serializer';
 import {SourceMapper} from './sourcemapper/sourcemapper';
 import {AllocationProfileNode} from './v8-types';
+import {isMainThread} from 'node:worker_threads';
 
 let enabled = false;
 let heapIntervalBytes = 0;
@@ -174,6 +175,7 @@ export function monitorOutOfMemory(
     dumpHeapProfileOnSdterr,
     exportCommand || [],
     newCallback,
-    typeof callbackMode !== 'undefined' ? callbackMode : CallbackMode.Async
+    typeof callbackMode !== 'undefined' ? callbackMode : CallbackMode.Async,
+    isMainThread
   );
 }


### PR DESCRIPTION
**What does this PR do?**:

In a worker thread, OOM is not fatal to the whole process and will only This is done by a callback registered by node, that's why we remove our callback and then call `LowMemoryNotification()` to trigger another garbage collection, which will eventually call the callback registered by node.

**Motivation**:
<!-- What inspired you to submit this pull request? -->

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

