### PR TITLE
Add labels to heap profiler

### DIFF
--- a/ts/src/heap-profiler.ts
+++ b/ts/src/heap-profiler.ts
@@ -24,7 +24,7 @@ import {
 } from './heap-profiler-bindings';
 import {serializeHeapProfile} from './profile-serializer';
 import {SourceMapper} from './sourcemapper/sourcemapper';
-import {AllocationProfileNode} from './v8-types';
+import {AllocationProfileNode, LabelSet} from './v8-types';
 import {isMainThread} from 'node:worker_threads';
 
 let enabled = false;
@@ -53,15 +53,22 @@ export function v8Profile(): AllocationProfileNode {
  */
 export function profile(
   ignoreSamplePath?: string,
-  sourceMapper?: SourceMapper
+  sourceMapper?: SourceMapper,
+  generateLabels?: (node: AllocationProfileNode) => LabelSet
 ): Profile {
-  return convertProfile(v8Profile(), ignoreSamplePath, sourceMapper);
+  return convertProfile(
+    v8Profile(),
+    ignoreSamplePath,
+    sourceMapper,
+    generateLabels
+  );
 }
 
 export function convertProfile(
   rootNode: AllocationProfileNode,
   ignoreSamplePath?: string,
-  sourceMapper?: SourceMapper
+  sourceMapper?: SourceMapper,
+  generateLabels?: (node: AllocationProfileNode) => LabelSet
 ): Profile {
   const startTimeNanos = Date.now() * 1000 * 1000;
   // Add node for external memory usage.
@@ -83,7 +90,8 @@ export function convertProfile(
     startTimeNanos,
     heapIntervalBytes,
     ignoreSamplePath,
-    sourceMapper
+    sourceMapper,
+    generateLabels
   );
 }
 

--- a/ts/src/profile-serializer.ts
+++ b/ts/src/profile-serializer.ts
@@ -371,16 +371,21 @@ export function serializeHeapProfile(
   startTimeNanos: number,
   intervalBytes: number,
   ignoreSamplesPath?: string,
-  sourceMapper?: SourceMapper
+  sourceMapper?: SourceMapper,
+  generateLabels?: (node: AllocationProfileNode) => LabelSet
 ): Profile {
   const appendHeapEntryToSamples: AppendEntryToSamples<
     AllocationProfileNode
   > = (entry: Entry<AllocationProfileNode>, samples: Sample[]) => {
     if (entry.node.allocations.length > 0) {
+      const labels = generateLabels
+        ? buildLabels(generateLabels(entry.node), stringTable)
+        : [];
       for (const alloc of entry.node.allocations) {
         const sample = new Sample({
           locationId: entry.stack,
           value: [alloc.count, alloc.sizeBytes * alloc.count],
+          label: labels,
           // TODO: add tag for allocation size
         });
         samples.push(sample);

--- a/ts/test/profiles-for-tests.ts
+++ b/ts/test/profiles-for-tests.ts
@@ -757,6 +757,70 @@ export const heapProfileIncludePath = new Profile({
   period: 524288,
 });
 
+export const heapProfileIncludePathWithLabels = new Profile({
+  sampleType: [
+    new ValueType({type: 1, unit: 2}),
+    new ValueType({type: 3, unit: 4}),
+  ],
+  sample: [
+    new Sample({
+      locationId: [2, 1],
+      value: [2, 4],
+      label: [
+        {
+          key: 5,
+          num: 0,
+          numUnit: 0,
+          str: 7,
+        },
+      ],
+    }),
+    new Sample({
+      locationId: [3, 1],
+      value: [1, 2],
+      label: [
+        {
+          key: 5,
+          num: 0,
+          numUnit: 0,
+          str: 7,
+        },
+      ],
+    }),
+    new Sample({
+      locationId: [5, 4],
+      value: [3, 6],
+      label: [
+        {
+          key: 5,
+          num: 0,
+          numUnit: 0,
+          str: 7,
+        },
+      ],
+    }),
+  ],
+  location: heapIncludePathLocations,
+  function: heapIncludePathFunctions,
+  stringTable: buildStringTable([
+    'objects',
+    'count',
+    'space',
+    'bytes',
+    'baz',
+    'foo.ts',
+    'bar',
+    '@google-cloud/profiler/profiler.ts',
+    'foo2',
+    'foo1',
+    'node_modules/@google-cloud/profiler/profiler.ts',
+    'bar.ts',
+  ]),
+  timeNanos: 0,
+  periodType: new ValueType({type: 3, unit: 4}),
+  period: 524288,
+});
+
 // heapProfile is encoded then decoded to convert numbers to longs, in
 // decodedHeapProfile
 const encodedHeapProfileIncludePath = heapProfileIncludePath.encode();


### PR DESCRIPTION
**What does this PR do?**:
`HeapProfiler.profile()` takes a new argument: a function that takes an`AllocationProfileNode` and returns a `LabelSet`.

**Motivation**:
Allow adding labels to heap profiles.

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

