### PR TITLE
[PROF-8802] Allow adding labels to wall profile even when contexts are not enabled

### DIFF
--- a/ts/src/profile-serializer.ts
+++ b/ts/src/profile-serializer.ts
@@ -261,7 +261,7 @@ export function serializeTimeProfile(
   intervalMicros: number,
   sourceMapper?: SourceMapper,
   recomputeSamplingInterval = false,
-  generateLabels?: (context: TimeProfileNodeContext) => LabelSet
+  generateLabels?: (context?: TimeProfileNodeContext) => LabelSet
 ): Profile {
   // If requested, recompute sampling interval from profile duration and total number of hits,
   // since profile duration should be #hits x interval.
@@ -300,9 +300,11 @@ export function serializeTimeProfile(
       }
     }
     if (unlabelledHits > 0) {
+      const labels = generateLabels ? generateLabels() : {};
       const sample = new Sample({
         locationId: entry.stack,
         value: [unlabelledHits, unlabelledHits * intervalNanos],
+        label: buildLabels(labels, stringTable),
       });
       samples.push(sample);
     }

--- a/ts/src/time-profiler.ts
+++ b/ts/src/time-profiler.ts
@@ -110,7 +110,7 @@ export function start({
 
 export function stop(
   restart = false,
-  generateLabels?: (context: TimeProfileNodeContext) => LabelSet
+  generateLabels?: (context?: TimeProfileNodeContext) => LabelSet
 ) {
   if (!gProfiler) {
     throw new Error('Wall profiler is not started');

--- a/ts/test/test-time-profiler.ts
+++ b/ts/test/test-time-profiler.ts
@@ -73,15 +73,20 @@ describe('Time Profiler', () => {
       initialContext['aaa'] = 'bbb';
 
       let endTime = 0n;
-      time.stop(false, (context: TimeProfileNodeContext) => {
+      time.stop(false, (context?: TimeProfileNodeContext) => {
+        assert.ok(context !== null, 'Context should not be null');
         if (!endTime) {
           endTime = BigInt(Date.now()) * 1000n;
         }
-        assert.deepEqual(context.context, initialContext, 'Unexpected context');
-        assert.ok(context.timestamp >= startTime);
-        assert.ok(context.timestamp <= endTime);
+        assert.deepEqual(
+          context!.context,
+          initialContext,
+          'Unexpected context'
+        );
+        assert.ok(context!.timestamp >= startTime);
+        assert.ok(context!.timestamp <= endTime);
         checked = true;
-        return {};
+        return {...context!.context};
       });
       assert(checked, 'No context found');
     });
@@ -121,7 +126,10 @@ describe('Time Profiler', () => {
         );
       }
 
-      function generateLabels(context: TimeProfileNodeContext) {
+      function generateLabels(context?: TimeProfileNodeContext) {
+        if (!context) {
+          return {};
+        }
         const labels: time.LabelSet = {};
         for (const [key, value] of Object.entries(context.context)) {
           if (typeof value === 'string') {


### PR DESCRIPTION
**What does this PR do?**:
* Make context argument to `generateLabels` optional
* Call `generateLabels` for unlabelled hits without arguments

**Motivation**:
Allow adding labels to samples without contexts.

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

