### PR TITLE
Bump major version in package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@datadog/pprof",
-  "version": "4.0.0-pre",
+  "version": "5.0.0-pre",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@datadog/pprof",
-      "version": "4.0.0-pre",
+      "version": "5.0.0-pre",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {


### PR DESCRIPTION
**What does this PR do?**:
Bump major version in package-lock.json

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

