### PR TITLE
[PROF-8678] Run tests with address sanitizer

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,20 @@ jobs:
       - run: npm install
       - run: npm run test:js-asan
 
+  valgrind:
+    strategy:
+      matrix:
+        version: [14, 16, 18, 20, 21]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.version }}
+      - run: sudo apt-get update && sudo apt-get install valgrind
+      - run: npm install
+      - run: npm run test:js-valgrind
+
   build:
     uses: Datadog/action-prebuildify/.github/workflows/build.yml@main
     with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,7 @@ jobs:
       package-manager: 'npm' # npm or yarn
       cache: true # enable caching of dependencies based on lockfile
       min-node-version: 14
+      skip: 'linux-arm linux-ia32' # skip building for these platforms
 
   dev_publish:
     needs: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,19 @@ on:
       - main
 
 jobs:
+  asan:
+    strategy:
+      matrix:
+        version: [14, 16, 18, 20, 21]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.version }}
+      - run: npm install
+      - run: npm run test:js-asan
+
   build:
     uses: Datadog/action-prebuildify/.github/workflows/build.yml@main
     with:

--- a/binding.gyp
+++ b/binding.gyp
@@ -1,8 +1,7 @@
 {
     "variables": {
-        "asan%": 0,
-        "lsan%": 0,
-        "ubsan%": 0,
+        "address_sanitizer%": 0, # enable address + undefined behaviour sanitizer
+        "thread_sanitizer%": 0, # enable thread sanitizer,
         "build_tests%": 0
     },
     "conditions": [
@@ -58,9 +57,62 @@
                 {
                     "defines": [
                         "NOMINMAX"
-                    ]
+                    ],
                 }
-            ]
-        ]
+            ],
+            ["address_sanitizer == 'true' and OS == 'mac'", {
+                'xcode_settings': {
+                    'OTHER_CFLAGS+': [
+                        '-fno-omit-frame-pointer',
+                        '-fsanitize=address,undefined',
+                        '-O0',
+                        '-g',
+                    ],
+                    'OTHER_CFLAGS!': [
+                        '-fomit-frame-pointer',
+                        '-O3',
+                    ],
+                },
+                'target_conditions': [
+                    ['_type!="static_library"', {
+                        'xcode_settings': {'OTHER_LDFLAGS+': ['-fsanitize=address,undefined']},
+                    }],
+                ],
+            }],
+            ["address_sanitizer == 'true' and OS != 'mac'", {
+                "cflags+": [
+                "-fno-omit-frame-pointer",
+                "-fsanitize=address,undefined",
+                "-O0",
+                "-g",
+                ],
+                "cflags!": [ "-fomit-frame-pointer", "-O3" ],
+                "ldflags+": [ "-fsanitize=address,undefined" ],
+            }],
+            ["thread_sanitizer == 'true' and OS == 'mac'", {
+                'xcode_settings': {
+                    'OTHER_CFLAGS+': [
+                        '-fno-omit-frame-pointer',
+                        '-fsanitize=thread',
+                    ],
+                    'OTHER_CFLAGS!': [
+                        '-fomit-frame-pointer',
+                    ],
+                },
+                'target_conditions': [
+                    ['_type!="static_library"', {
+                        'xcode_settings': {'OTHER_LDFLAGS+': ['-fsanitize=thread']},
+                    }],
+                ],
+            }],
+            ["thread_sanitizer == 'true' and OS != 'mac'", {
+                "cflags+": [
+                "-fno-omit-frame-pointer",
+                "-fsanitize=thread",
+                ],
+                "cflags!": [ "-fomit-frame-pointer" ],
+                "ldflags+": [ "-fsanitize=thread" ],
+            }]
+        ],
     }
 }

--- a/binding.gyp
+++ b/binding.gyp
@@ -58,6 +58,33 @@
                     "defines": [
                         "NOMINMAX"
                     ],
+                    'msvs_settings': {
+                        'VCCLCompilerTool': {
+                            'AdditionalOptions': [
+                                '/Zc:__cplusplus',
+                                '-std:c++17',
+                            ],
+                        },                        
+                    },
+                },
+            ],
+            ["OS == 'linux'",
+                {
+                "cflags+":
+                    ["-Wno-deprecated-declarations", "-Werror"],
+                "cflags_cc!": ["-std=gnu++14", "-std=gnu++1y"],
+                "cflags_cc": ["-std=gnu++17"],
+                }
+            ],
+            ["OS == 'mac'",
+                {
+                'xcode_settings': {
+                    'OTHER_CFLAGS+': [
+                        "-Wno-deprecated-declarations",
+                        "-Werror",
+                        '-std=gnu++17',
+                        ],
+                    },
                 }
             ],
             ["address_sanitizer == 'true' and OS == 'mac'", {

--- a/bindings/binding.cc
+++ b/bindings/binding.cc
@@ -38,7 +38,15 @@ static NAN_METHOD(GetNativeThreadId) {
   info.GetReturnValue().Set(v8::Integer::New(info.GetIsolate(), native_id));
 }
 
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-function-type"
+#endif
 NODE_MODULE_INIT(/* exports, module, context */) {
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+
   dd::HeapProfiler::Init(exports);
   dd::WallProfiler::Init(exports);
   Nan::SetMethod(exports, "getNativeThreadId", GetNativeThreadId);

--- a/bindings/defer.hh
+++ b/bindings/defer.hh
@@ -64,4 +64,4 @@ details::DeferHolder<F> make_defer(F&& f) {
 #define DEFER_(LINE) zz_defer##LINE
 #define DEFER(LINE) DEFER_(LINE)
 #define defer                                                                  \
-  [[gnu::unused]] const auto& DEFER(__COUNTER__) = details::DeferDummy{}* [&]()
+  [[maybe_unused]] const auto& DEFER(__COUNTER__) = details::DeferDummy{}* [&]()

--- a/bindings/profilers/wall.cc
+++ b/bindings/profilers/wall.cc
@@ -941,6 +941,7 @@ NAN_MODULE_INIT(WallProfiler::Init) {
 
   Nan::SetPrototypeMethod(tpl, "start", Start);
   Nan::SetPrototypeMethod(tpl, "stop", Stop);
+  Nan::SetPrototypeMethod(tpl, "dispose", Dispose);
   Nan::SetPrototypeMethod(tpl,
                           "v8ProfilerStuckEventLoopDetected",
                           V8ProfilerStuckEventLoopDetected);
@@ -1034,6 +1035,11 @@ NAN_GETTER(WallProfiler::SharedArrayGetter) {
 NAN_METHOD(WallProfiler::V8ProfilerStuckEventLoopDetected) {
   auto profiler = Nan::ObjectWrap::Unwrap<WallProfiler>(info.Holder());
   info.GetReturnValue().Set(profiler->v8ProfilerStuckEventLoopDetected());
+}
+
+NAN_METHOD(WallProfiler::Dispose) {
+  auto profiler = Nan::ObjectWrap::Unwrap<WallProfiler>(info.Holder());
+  delete profiler;
 }
 
 void WallProfiler::PushContext(int64_t time_from,

--- a/bindings/profilers/wall.cc
+++ b/bindings/profilers/wall.cc
@@ -348,7 +348,7 @@ static int64_t GetV8ToEpochOffset() {
   // every minute) instead of once statically, as the difference doesn't
   // necessarily remain constant depending on the characteristics of the clocks
   // being used.
-  int64_t V8toEpochOffset;
+  int64_t V8toEpochOffset = 0;
   int64_t smallestDiff = std::numeric_limits<int64_t>::max();
   for (int i = 0; i < MAX_EPOCH_OFFSET_ATTEMPTS; ++i) {
     auto v8Now = Now();
@@ -777,7 +777,7 @@ bool WallProfiler::waitForSignal(uint64_t targetCallCount) {
   }
 #if DD_WALL_USE_SIGPROF
   const int maxRetries = 2;
-  // wait for a maximum of 2 sample period
+  // wait for a maximum of 2 sample periods
   // if a signal occurs it will interrupt sleep (we use nanosleep and not
   // uv_sleep because we want this behaviour)
   timespec ts = {

--- a/bindings/profilers/wall.hh
+++ b/bindings/profilers/wall.hh
@@ -147,6 +147,7 @@ class WallProfiler : public Nan::ObjectWrap {
   static NAN_METHOD(Start);
   static NAN_METHOD(Stop);
   static NAN_METHOD(V8ProfilerStuckEventLoopDetected);
+  static NAN_METHOD(Dispose);
   static NAN_MODULE_INIT(Init);
   static NAN_GETTER(GetContext);
   static NAN_SETTER(SetContext);

--- a/bindings/test/binding.cc
+++ b/bindings/test/binding.cc
@@ -23,7 +23,15 @@
 #include "tap.h"
 #include "v8.h"
 
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-function-type"
+#endif
 NODE_MODULE_INIT(/* exports, module, context */) {
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+
   Tap t;
   const char* env_var = std::getenv("TEST");
   std::string name(env_var == nullptr ? "" : env_var);

--- a/package.json
+++ b/package.json
@@ -6,19 +6,25 @@
   "main": "out/src/index.js",
   "types": "out/src/index.d.ts",
   "scripts": {
-    "install": "exit 0",
-    "rebuild": "node-gyp rebuild --jobs=max",
-    "test:js": "nyc mocha -r source-map-support/register out/test/test-*.js",
-    "test:cpp": "node scripts/cctest.js",
-    "test:wall": "nyc mocha -r source-map-support/register out/test/test-time-profiler.js",
-    "test": "npm run test:js && npm run test:cpp",
+    "build:asan": "node-gyp configure build --jobs=max --address_sanitizer",
+    "build:tsan": "node-gyp configure build --jobs=max --thread_sanitizer",
+    "build": "node-gyp configure build --jobs=max --verbose",
     "codecov": "nyc report --reporter=json && codecov -f coverage/*.json",
     "compile": "tsc -p .",
     "fix": "gts fix",
-    "lint": "jsgl --local . && gts check && clang-format --style file -n -Werror --glob='bindings/**/*.{h,hh,cpp,cc}'",
     "format": "clang-format --style file -i --glob='bindings/**/*.{h,hh,cpp,cc}'",
+    "install": "exit 0",
+    "lint": "jsgl --local . && gts check && clang-format --style file -n -Werror --glob='bindings/**/*.{h,hh,cpp,cc}'",
     "prepare": "npm run compile && npm run rebuild",
-    "pretest": "npm run compile"
+    "pretest:js-asan": "npm run compile && npm run build:asan",
+    "pretest:js-tsan": "npm run compile && npm run build:tsan",
+    "pretest": "npm run compile",
+    "rebuild": "node-gyp rebuild --jobs=max",
+    "test:cpp": "node scripts/cctest.js",
+    "test:js-asan": "LSAN_OPTIONS='suppressions=./suppressions/lsan_suppr.txt' LD_PRELOAD=`gcc -print-file-name=libasan.so` mocha out/test/test-*.js",
+    "test:js-tsan": "LD_PRELOAD=`gcc -print-file-name=libtsan.so` mocha out/test/test-*.js",
+    "test:js": "nyc mocha -r source-map-support/register out/test/test-*.js",
+    "test": "npm run test:js && npm run test:cpp"
   },
   "author": {
     "name": "Google Inc."

--- a/package.json
+++ b/package.json
@@ -18,11 +18,13 @@
     "prepare": "npm run compile && npm run rebuild",
     "pretest:js-asan": "npm run compile && npm run build:asan",
     "pretest:js-tsan": "npm run compile && npm run build:tsan",
+    "pretest:js-valgrind": "npm run pretest",
     "pretest": "npm run compile",
     "rebuild": "node-gyp rebuild --jobs=max",
     "test:cpp": "node scripts/cctest.js",
     "test:js-asan": "LSAN_OPTIONS='suppressions=./suppressions/lsan_suppr.txt' LD_PRELOAD=`gcc -print-file-name=libasan.so` mocha out/test/test-*.js",
     "test:js-tsan": "LD_PRELOAD=`gcc -print-file-name=libtsan.so` mocha out/test/test-*.js",
+    "test:js-valgrind": "valgrind --leak-check=full mocha out/test/test-*.js",
     "test:js": "nyc mocha -r source-map-support/register out/test/test-*.js",
     "test": "npm run test:js && npm run test:cpp"
   },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "build:asan": "node-gyp configure build --jobs=max --address_sanitizer",
     "build:tsan": "node-gyp configure build --jobs=max --thread_sanitizer",
-    "build": "node-gyp configure build --jobs=max --verbose",
+    "build": "node-gyp configure build --jobs=max",
     "codecov": "nyc report --reporter=json && codecov -f coverage/*.json",
     "compile": "tsc -p .",
     "fix": "gts fix",

--- a/scripts/cctest.js
+++ b/scripts/cctest.js
@@ -7,13 +7,9 @@ const { join } = require('path')
 const name = process.argv[2] || 'test_dd_pprof'
 
 const cmd = [
-  'node-gyp rebuild',
-  '--release',
-  '--jobs=max',
-  '--build_v8_with_gn=false',
-  '--v8_enable_pointer_compression=""',
-  '--v8_enable_31bit_smis_on_64bit_arch=""',
-  '--enable_lto=false',
+  'node-gyp',
+  'configure',
+  'build',
   '--build_tests'
 ].join(' ')
 

--- a/suppressions/lsan_suppr.txt
+++ b/suppressions/lsan_suppr.txt
@@ -1,0 +1,1 @@
+leak:PKCS5_PBKDF2_HMAC

--- a/ts/src/time-profiler.ts
+++ b/ts/src/time-profiler.ts
@@ -134,6 +134,7 @@ export function stop(
     generateLabels
   );
   if (!restart) {
+    gProfiler.dispose();
     gProfiler = undefined;
     gSourceMapper = undefined;
   }

--- a/ts/test/test-time-profiler.ts
+++ b/ts/test/test-time-profiler.ts
@@ -339,6 +339,7 @@ describe('Time Profiler', () => {
     const timeProfilerStub = {
       start: sinon.stub(),
       stop: sinon.stub().returns(v8TimeProfile),
+      dispose: sinon.stub(),
       v8ProfilerStuckEventLoopDetected: sinon.stub().returns(0),
     };
 
@@ -400,6 +401,7 @@ describe('Time Profiler', () => {
     const timeProfilerStub = {
       start: sinon.stub(),
       stop: sinon.stub().returns(v8TimeProfile),
+      dispose: sinon.stub(),
       v8ProfilerStuckEventLoopDetected: sinon.stub().returns(2),
     };
 


### PR DESCRIPTION
**What does this PR do?**:

* Compile and run tests with address sanitizer in CI
* Add target to compile and run tests with thread sanitizer (not run in CI because of errors)
* Run tests with valgrind in CI
* Fix warnings and turn warnings into errors on Linux and MacOS
* Manually destroy native WallProfiler object upon stop:
    GC is not guaranteed to run and native object might not be destroyed and worker threads in particular could leak memory.
* Enable c++17 for all platforms
* Disable build on armv7

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

