### PR TITLE
Make OOM test work on Windows

### DIFF
--- a/ts/test/test-heap-profiler.ts
+++ b/ts/test/test-heap-profiler.ts
@@ -213,13 +213,8 @@ describe('HeapProfiler', () => {
 
 describe('OOMMonitoring', () => {
   it('should call external process upon OOM', async function () {
-    // On Windows, OOM monitoring does not work well, in particular
-    // it appears that calling GetAllocationProfile in NearHeapLimitCallback
-    // causes the process to abort. So we skip this test on Windows.
-    if (process.platform === 'win32') this.skip();
-
     // this test is very slow on some configs (asan/valgrind)
-    this.timeout(10000);
+    this.timeout(20000);
     const proc = fork(path.join(__dirname, 'oom.js'), {
       execArgv: ['--max-old-space-size=50'],
     });


### PR DESCRIPTION
**What does this PR do?**:
 uv_fs_mkstemp() is not used because it fails unexpectedly on Windows (fail fast exception is raised when trying to write to the returned file descriptor.

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

