### PR TITLE
Make sure to not report wall time as part of non-JS threads

### DIFF
--- a/bindings/profilers/wall.cc
+++ b/bindings/profilers/wall.cc
@@ -856,7 +856,7 @@ Result WallProfiler::StopImpl(bool restart, v8::Local<v8::Value>& profile) {
   if (withContexts_) {
     int64_t nonJSThreadsCpuTime{};
 
-    if (isMainThread_) {
+    if (isMainThread_ && collectCpuTime_) {
       // account for non-JS threads CPU only in main thread
       // CPU time of non-JS threads is the difference between process CPU time
       // and sum of all worker JS thread during the profiling period of main

--- a/ts/src/profile-serializer.ts
+++ b/ts/src/profile-serializer.ts
@@ -354,7 +354,7 @@ export function serializeTimeProfile(
     period: intervalNanos,
   };
 
-  if (prof.nonJSThreadsCpuTime) {
+  if (prof.hasCpuTime && prof.nonJSThreadsCpuTime) {
     const node: TimeProfileNode = {
       name: NON_JS_THREADS_FUNCTION_NAME,
       scriptName: '',

--- a/ts/src/profile-serializer.ts
+++ b/ts/src/profile-serializer.ts
@@ -306,7 +306,10 @@ export function serializeTimeProfile(
         ? generateLabels({node: entry.node, context})
         : context.context;
       if (Object.keys(labels).length > 0) {
-        const values = [1, intervalNanos];
+        // Only assign wall time if there are hits, some special nodes such as `(Non-JS threads)`
+        // have zero hit count (since they do not count as wall time) and should not be assigned any
+        // wall time.
+        const values = unlabelledHits > 0 ? [1, intervalNanos] : [0, 0];
         if (prof.hasCpuTime) {
           values.push(context.cpuTime);
         }
@@ -323,7 +326,10 @@ export function serializeTimeProfile(
     }
     if (unlabelledHits > 0 || unlabelledCpuTime > 0) {
       const labels = generateLabels ? generateLabels({node: entry.node}) : {};
-      const values = [unlabelledHits, unlabelledHits * intervalNanos];
+      const values =
+        unlabelledHits > 0
+          ? [unlabelledHits, unlabelledHits * intervalNanos]
+          : [0, 0];
       if (prof.hasCpuTime) {
         values.push(unlabelledCpuTime);
       }

--- a/ts/test/profiles-for-tests.ts
+++ b/ts/test/profiles-for-tests.ts
@@ -24,6 +24,8 @@ import {Function, Location, Profile, Sample, ValueType} from 'pprof-format';
 import {TimeProfile} from '../src/v8-types';
 import {StringTable} from 'pprof-format';
 
+import assert from 'assert';
+
 function buildStringTable(values: string[]): StringTable {
   const table = new StringTable();
   for (const value of values) {
@@ -1224,3 +1226,33 @@ export const labelEncodingProfile = {
     ],
   },
 };
+
+const {hasOwnProperty} = Object.prototype;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function getAndVerifyPresence(
+  list: any[],
+  id: number,
+  zeroIndex = false
+) {
+  assert.strictEqual(typeof id, 'number', 'has id');
+  const index = id - (zeroIndex ? 0 : 1);
+  assert.ok(list.length > index, 'exists in list');
+  return list[index];
+}
+
+export function getAndVerifyString(
+  stringTable: StringTable,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  source: any,
+  field: string
+) {
+  assert.ok(hasOwnProperty.call(source, field), 'has id field');
+  const str = getAndVerifyPresence(
+    stringTable.strings,
+    source[field] as number,
+    true
+  );
+  assert.strictEqual(typeof str, 'string', 'is a string');
+  return str;
+}


### PR DESCRIPTION
**What does this PR do?**:

This fix two bugs related to non-JS threads CPU time reporting:
* Avoid computing/reporting non-JS threads CPU time when CPU profiler is not enabled
* Report zero wall time in non-JS threads CPU time sample: all contexts with labels for a given profile node were counted as one wall time sample 

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

