### PR TITLE
Rename special frames

### DIFF
--- a/ts/src/time-profiler.ts
+++ b/ts/src/time-profiler.ts
@@ -18,6 +18,7 @@ import delay from 'delay';
 
 import {
   serializeTimeProfile,
+  GARBAGE_COLLECTION_FUNCTION_NAME,
   NON_JS_THREADS_FUNCTION_NAME,
 } from './profile-serializer';
 import {SourceMapper} from './sourcemapper/sourcemapper';
@@ -171,5 +172,9 @@ export function v8ProfilerStuckEventLoopDetected() {
   return gV8ProfilerStuckEventLoopDetected;
 }
 
-export const constants = {kSampleCount, NON_JS_THREADS_FUNCTION_NAME};
+export const constants = {
+  kSampleCount,
+  GARBAGE_COLLECTION_FUNCTION_NAME,
+  NON_JS_THREADS_FUNCTION_NAME,
+};
 export {getNativeThreadId};

--- a/ts/test/profiles-for-tests.ts
+++ b/ts/test/profiles-for-tests.ts
@@ -84,7 +84,7 @@ const timeNode2 = {
   children: [timeLeaf3],
 };
 
-const timeRoot = {
+const timeRoot = Object.freeze({
   name: '(root)',
   scriptName: 'root',
   scriptId: 0,
@@ -92,7 +92,7 @@ const timeRoot = {
   columnNumber: 0,
   hitCount: 0,
   children: [timeNode1, timeNode2],
-};
+});
 
 export const v8TimeProfile: TimeProfile = Object.freeze({
   startTime: 0,

--- a/ts/test/test-profile-serializer.ts
+++ b/ts/test/test-profile-serializer.ts
@@ -192,7 +192,7 @@ describe('profile-serializer', () => {
       const heapProfileOut = serializeHeapProfile(v8HeapProfile, 0, 512 * 1024);
       assert.deepEqual(heapProfileOut, heapProfile);
     });
-    it('should produce expected profile when there is anyonmous function', () => {
+    it('should produce expected profile when there is anonymous function', () => {
       const heapProfileOut = serializeHeapProfile(
         v8AnonymousFunctionHeapProfile,
         0,


### PR DESCRIPTION
**What does this PR do?**:
* Rename `(garbage collector)` to `Garbage Collection`
* Rename `(non-JS threads)` to `(Non JS threads activity)`
* Place these frame under a `Node.js` parent frame

**Motivation**:
Make the UI easier to understand and more consistent with other profilers.


**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

