### PR TITLE
[PROF-9213] Add support for mjs/cjs source maps

### DIFF
--- a/ts/src/profile-serializer.ts
+++ b/ts/src/profile-serializer.ts
@@ -107,6 +107,12 @@ function serialize<T extends ProfileNode>(
   while (entries.length > 0) {
     const entry = entries.pop()!;
     const node = entry.node;
+
+    // mjs files have a `file://` prefix in the scriptName -> remove it
+    if (node.scriptName.startsWith('file://')) {
+      node.scriptName = node.scriptName.slice(7);
+    }
+
     if (ignoreSamplesPath && node.scriptName.indexOf(ignoreSamplesPath) > -1) {
       continue;
     }

--- a/ts/src/sourcemapper/sourcemapper.ts
+++ b/ts/src/sourcemapper/sourcemapper.ts
@@ -359,11 +359,7 @@ async function getMapFiles(baseDir: string): Promise<string[]> {
   const mapFiles: string[] = [];
   for await (const entry of walk(
     baseDir,
-    filename =>
-      filename.endsWith('js.map') &&
-      (filename.endsWith('.js.map') ||
-        filename.endsWith('.cjs.map') ||
-        filename.endsWith('.mjs.map')),
+    filename => /\.[cm]?js\.map$/.test(filename),
     (root, dirname) =>
       root !== '/proc' && dirname !== '.git' && dirname !== 'node_modules'
   )) {

--- a/ts/src/sourcemapper/sourcemapper.ts
+++ b/ts/src/sourcemapper/sourcemapper.ts
@@ -359,7 +359,11 @@ async function getMapFiles(baseDir: string): Promise<string[]> {
   const mapFiles: string[] = [];
   for await (const entry of walk(
     baseDir,
-    filename => filename.endsWith('.js.map'),
+    filename =>
+      filename.endsWith('js.map') &&
+      (filename.endsWith('.js.map') ||
+        filename.endsWith('.cjs.map') ||
+        filename.endsWith('.mjs.map')),
     (root, dirname) =>
       root !== '/proc' && dirname !== '.git' && dirname !== 'node_modules'
   )) {


### PR DESCRIPTION
**What does this PR do?**:

Add support for mjs/cjs source maps:
* Look for `.js.map` / `.mjs.map` / `.cjs.map`
* Remove `file://` prefix present in locations from `.mjs` files

**Motivation**:
Support bundles generated with esbuild with `--format=esm`.

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

