### PR TITLE
PROF-9395: Use `Profile.encodeAsync()`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "delay": "^5.0.0",
         "node-gyp-build": "<4.0",
         "p-limit": "^3.1.0",
-        "pprof-format": "^2.0.7",
+        "pprof-format": "^2.1.0",
         "source-map": "^0.7.4"
       },
       "devDependencies": {
@@ -5316,9 +5316,9 @@
       }
     },
     "node_modules/pprof-format": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/pprof-format/-/pprof-format-2.0.7.tgz",
-      "integrity": "sha512-1qWaGAzwMpaXJP9opRa23nPnt2Egi7RMNoNBptEE/XwHbcn4fC2b/4U4bKc5arkGkIh2ZabpF2bEb+c5GNHEKA=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pprof-format/-/pprof-format-2.1.0.tgz",
+      "integrity": "sha512-0+G5bHH0RNr8E5hoZo/zJYsL92MhkZjwrHp3O2IxmY8RJL9ooKeuZ8Tm0ZNBw5sGZ9TiM71sthTjWoR2Vf5/xw=="
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "delay": "^5.0.0",
     "node-gyp-build": "<4.0",
     "p-limit": "^3.1.0",
-    "pprof-format": "^2.0.7",
+    "pprof-format": "^2.1.0",
     "source-map": "^0.7.4"
   },
   "devDependencies": {

--- a/ts/src/profile-encoder.ts
+++ b/ts/src/profile-encoder.ts
@@ -21,8 +21,8 @@ import {Profile} from 'pprof-format';
 
 const gzipPromise = promisify(gzip);
 
-export async function encode(profile: Profile): Promise<Buffer> {
-  return gzipPromise(profile.encode());
+export function encode(profile: Profile): Promise<Buffer> {
+  return profile.encodeAsync().then(gzipPromise);
 }
 
 export function encodeSync(profile: Profile): Buffer {


### PR DESCRIPTION
**What does this PR do?**:
Uses `Profile.encodeAsync()` from pprof-format 2.1.0 in the profile encoding method.

**Motivation**:
Lowering the latency spikes caused by profile encoding.

**How to test the change?**:
Existing `profile-encoded/encode` test fails when this is broken.
 
**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
