### PR TITLE
Update actions/download-artifacts to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,9 @@ jobs:
       NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
       - uses: actions/setup-node@v3
         with:
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,9 @@ jobs:
       NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
       - uses: actions/setup-node@v3
         with:
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
**What does this PR do?**:
Update `actions/download-artifacts` to v4.

**Motivation**:
This is required following the update of `actions/upload-artifacts` to v4 in prebuildify.
