### PR TITLE
Download artifact from prebuilds job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v4
         with:
-          merge-multiple: true
+          name: prebuilds
       - uses: actions/setup-node@v3
         with:
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v4
         with:
-          merge-multiple: true
+          name: prebuilds
       - uses: actions/setup-node@v3
         with:
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
**What does this PR do?**:
Only retrieve `prebuilds` artifact.

**Motivation**:
No need to retrieve all artifacts and merge them.