### PR TITLE
Fix artifact download

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,8 +53,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v4
-        with:
-          name: prebuilds
       - uses: actions/setup-node@v3
         with:
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,12 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - run: npm install
       - run: npm publish
+
+  tag:
+    needs: publish
+    permissions:
+      content: write
+    steps:
       - id: pkg
         run: |
           content=`cat ./package.json | tr '\n' ' '`

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,8 +24,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v4
-        with:
-          name: prebuilds
       - uses: actions/setup-node@v3
         with:
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
* Fixes release artifact download to conform to https://github.com/DataDog/action-prebuildify/pull/43
* Tries to fix permissions for tagging the repo on release.

Jira: [PROF-10740] (still trying to do a release for Node 23)



[PROF-10740]: https://datadoghq.atlassian.net/browse/PROF-10740?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ