### PR TITLE
Revert the incorrect fix for tagging permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,8 @@ jobs:
     environment: npm
     env:
       NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    permissions:
+      content: write
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,12 +29,6 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - run: npm install
       - run: npm publish
-
-  tag:
-    needs: publish
-    permissions:
-      content: write
-    steps:
       - id: pkg
         run: |
           content=`cat ./package.json | tr '\n' ' '`


### PR DESCRIPTION
* Undoes the bad fix for permissions for tagging the repo on release.

Jira: [PROF-10740] (still trying to do a release for Node 23)

[PROF-10740]: https://datadoghq.atlassian.net/browse/PROF-10740?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ