### PR TITLE
Disable benchmark run on tags

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -5,7 +5,10 @@ variables:
   tags: ["runner:apm-k8s-tweaked-metal"]
   image: $BASE_CI_IMAGE
   stage: benchmarks
-  when: on_success
+  rules:
+    - if: $CI_COMMIT_TAG
+      when: never
+    - when: on_success
   variables:
     UPSTREAM_PROJECT_ID: $CI_PROJECT_ID
     UPSTREAM_PROJECT_NAME: $CI_PROJECT_NAME


### PR DESCRIPTION
**What does this PR do?**:

Disable benchmark run on tags.

**Motivation**:

Baseline commit determination in benchmarks fails when gitlab pipeline is triggered by a tag.
