### PR TITLE
use atomic load/store on curContext_

### DIFF
--- a/bindings/profilers/wall.hh
+++ b/bindings/profilers/wall.hh
@@ -51,11 +51,7 @@ class WallProfiler : public Nan::ObjectWrap {
   // avoid heap allocation. Need to figure out the right move/copy semantics in
   // and out of the ring buffer.
 
-  // We're using a pair of shared pointers and an atomic pointer-to-current as
-  // a way to ensure signal safety on update.
-  ContextPtr context1_;
-  ContextPtr context2_;
-  std::atomic<ContextPtr*> curContext_;
+  ContextPtr curContext_;
 
   std::atomic<CollectionMode> collectionMode_;
   std::atomic<uint64_t> noCollectCallCount_;
@@ -99,6 +95,7 @@ class WallProfiler : public Nan::ObjectWrap {
                                    int64_t startCpuTime);
 
   bool waitForSignal(uint64_t targetCallCount = 0);
+  ContextPtr GetContextPtr();
 
  public:
   /**


### PR DESCRIPTION
**What does this PR do?**:
Instead of a pair of `ContextPtr` objects (which are a `std::shared_ptr<v8::Global<v8::Value>>`) and an atomic pointer that switches between them, we use just one `ContextPtr` and use `std::atomic_{load|store}_explicit(std::shared_ptr)` to atomically load/store into it. 

**Motivation**:
While doing #186 I realized this can be done and it simplifies the code. It makes evolving the code towards that PR simpler too. 