### PR TITLE
Capture Node execution async ID with samples

### DIFF
--- a/bindings/profilers/wall.hh
+++ b/bindings/profilers/wall.hh
@@ -82,6 +82,7 @@ class WallProfiler : public Nan::ObjectWrap {
     int64_t time_from;
     int64_t time_to;
     int64_t cpu_time;
+    double async_id;
   };
 
   using ContextBuffer = std::vector<SampleContext>;
@@ -118,7 +119,10 @@ class WallProfiler : public Nan::ObjectWrap {
 
   v8::Local<v8::Value> GetContext(v8::Isolate*);
   void SetContext(v8::Isolate*, v8::Local<v8::Value>);
-  void PushContext(int64_t time_from, int64_t time_to, int64_t cpu_time);
+  void PushContext(int64_t time_from,
+                   int64_t time_to,
+                   int64_t cpu_time,
+                   double async_id);
   Result StartImpl();
   std::string StartInternal();
   Result StopImpl(bool restart, v8::Local<v8::Value>& profile);

--- a/ts/src/profile-serializer.ts
+++ b/ts/src/profile-serializer.ts
@@ -326,6 +326,7 @@ function updateTimeProfile(prof: TimeProfile): TimeProfile {
           context: {},
           timestamp: BigInt(0),
           cpuTime: prof.nonJSThreadsCpuTime,
+          asyncId: -1,
         },
       ],
     };

--- a/ts/src/v8-types.ts
+++ b/ts/src/v8-types.ts
@@ -41,6 +41,7 @@ export interface TimeProfileNodeContext {
   context: object;
   timestamp: bigint; // end of sample taking; in microseconds since epoch
   cpuTime: number; // cpu time in nanoseconds
+  asyncId: number; // async_hooks.executionAsyncId() at the time of sample taking
 }
 
 export interface TimeProfileNode extends ProfileNode {

--- a/ts/test/test-time-profiler.ts
+++ b/ts/test/test-time-profiler.ts
@@ -135,6 +135,10 @@ describe('Time Profiler', () => {
         if (!context) {
           return {};
         }
+        assert(
+          typeof context.asyncId === 'number',
+          'context.asyncId should be a number'
+        );
         const labels: LabelSet = {};
         for (const [key, value] of Object.entries(context.context)) {
           if (typeof value === 'string') {


### PR DESCRIPTION
**What does this PR do?**:
Captures `node::AsyncHooksGetExecutionAsyncId` with wall/CPU samples and exposes it as `TimeProfileNodeContext.asyncId` to downstream users – this can typically be leveraged from `generateLabels` implementations.

**Motivation**:
By correlating timestamped samples with Node async IDs we can detect longer executions within the same async context, indicating a blocked event loop. We already do this but rely on tracing span IDs; this solution makes this profiler capability independent of tracing.

**Additional Notes**:
The `AsyncHooksGetExecutionAsyncId` API returns `-1` when it can't find the `node::Environment` in the current `v8::Context`. There are some operations that V8 turboshaft compiler intrinsifies – e.g. `Date.now()` and some string operations – and those are invoked without a context. If sampling happens when these run, we will fail to capture the async ID (the failure is benign, it only manifests itself as `-1` being returned as async ID.)

JIRA: [PROF-11107]

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->




[PROF-11107]: https://datadoghq.atlassian.net/browse/PROF-11107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ