### PR TITLE
Prevent GCC using FP registers for pointer storage on arm64 Linux

### DIFF
--- a/bindings/general-regs-only.hh
+++ b/bindings/general-regs-only.hh
@@ -16,12 +16,8 @@
 
 #pragma once
 
-#include <v8-profiler.h>
-#include "general-regs-only.hh"
-
-namespace dd {
-
-v8::Local<v8::Value> TranslateAllocationProfile(
-    v8::AllocationProfile::Node* node) GENERAL_REGS_ONLY;
-
-}  // namespace dd
+#if defined(__linux__) && defined(__aarch64__)
+#define GENERAL_REGS_ONLY __attribute__((target("general-regs-only")))
+#else
+#define GENERAL_REGS_ONLY
+#endif

--- a/bindings/profilers/heap.hh
+++ b/bindings/profilers/heap.hh
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <nan.h>
+#include "general-regs-only.hh"
 
 namespace dd {
 
@@ -34,7 +35,7 @@ class HeapProfiler {
   // getAllocationProfile(): AllocationProfileNode
   static NAN_METHOD(GetAllocationProfile);
 
-  static NAN_METHOD(MonitorOutOfMemory);
+  static NAN_METHOD(MonitorOutOfMemory) GENERAL_REGS_ONLY;
 
   static NAN_MODULE_INIT(Init);
 };

--- a/bindings/profilers/wall.cc
+++ b/bindings/profilers/wall.cc
@@ -321,7 +321,8 @@ void SignalHandler::HandleProfilerSignal(int sig,
   auto time_from = Now();
   old_handler(sig, info, context);
   auto time_to = Now();
-  double async_id = node::AsyncHooksGetExecutionAsyncId(isolate);
+  int64_t async_id =
+      static_cast<int64_t>(node::AsyncHooksGetExecutionAsyncId(isolate));
   prof->PushContext(time_from, time_to, cpu_time, async_id);
 }
 #else
@@ -369,10 +370,17 @@ static int64_t GetV8ToEpochOffset() {
   return V8toEpochOffset;
 }
 
-ContextsByNode WallProfiler::GetContextsByNode(CpuProfile* profile,
-                                               ContextBuffer& contexts,
-                                               int64_t startCpuTime) {
-  ContextsByNode contextsByNode;
+Local<Number> NewNumberFromInt64(Isolate* isolate, int64_t value) {
+  return Number::New(isolate, static_cast<double>(value));
+}
+
+std::shared_ptr<ContextsByNode> CreateContextsByNode() {
+  return std::make_shared<ContextsByNode>();
+}
+
+std::shared_ptr<ContextsByNode> WallProfiler::GetContextsByNode(
+    CpuProfile* profile, ContextBuffer& contexts, int64_t startCpuTime) {
+  auto contextsByNode = CreateContextsByNode();
 
   auto sampleCount = profile->GetSamplesCount();
   if (contexts.empty() || sampleCount == 0) {
@@ -432,11 +440,11 @@ ContextsByNode WallProfiler::GetContextsByNode(CpuProfile* profile,
         break;
       } else {
         // This sample context is the closest to this sample.
-        auto it = contextsByNode.find(sample);
+        auto it = contextsByNode->find(sample);
         Local<Array> array;
-        if (it == contextsByNode.end()) {
+        if (it == contextsByNode->end()) {
           array = Array::New(isolate);
-          contextsByNode[sample] = {array, 1};
+          (*contextsByNode)[sample] = {array, 1};
         } else {
           array = it->second.contexts;
           ++it->second.hitcount;
@@ -459,17 +467,17 @@ ContextsByNode WallProfiler::GetContextsByNode(CpuProfile* profile,
           // sample
           if (collectCpuTime_ && !isIdleOrProgram(sample)) {
             timedContext
-                ->Set(
-                    v8Context,
-                    cpuTimeKey,
-                    Number::New(isolate, sampleContext.cpu_time - lastCpuTime))
+                ->Set(v8Context,
+                      cpuTimeKey,
+                      NewNumberFromInt64(isolate,
+                                         sampleContext.cpu_time - lastCpuTime))
                 .Check();
             lastCpuTime = sampleContext.cpu_time;
           }
           timedContext
               ->Set(v8Context,
                     asyncIdKey,
-                    Number::New(isolate, sampleContext.async_id))
+                    NewNumberFromInt64(isolate, sampleContext.async_id))
               .Check();
           array->Set(v8Context, array->Length(), timedContext).Check();
         }
@@ -881,7 +889,7 @@ Result WallProfiler::StopImpl(bool restart, v8::Local<v8::Value>& profile) {
 
     profile = TranslateTimeProfile(v8_profile,
                                    includeLines_,
-                                   &contextsByNode,
+                                   contextsByNode,
                                    collectCpuTime_,
                                    nonJSThreadsCpuTime);
 
@@ -1018,7 +1026,7 @@ NAN_METHOD(WallProfiler::Dispose) {
 void WallProfiler::PushContext(int64_t time_from,
                                int64_t time_to,
                                int64_t cpu_time,
-                               double async_id) {
+                               int64_t async_id) {
   // Be careful this is called in a signal handler context therefore all
   // operations must be async signal safe (in particular no allocations).
   // Our ring buffer avoids allocations.

--- a/bindings/translate-time-profile.cc
+++ b/bindings/translate-time-profile.cc
@@ -15,6 +15,7 @@
  */
 
 #include "translate-time-profile.hh"
+#include "general-regs-only.hh"
 #include "profile-translator.hh"
 
 namespace dd {
@@ -22,7 +23,7 @@ namespace dd {
 namespace {
 class TimeProfileTranslator : ProfileTranslator {
  private:
-  ContextsByNode* contextsByNode;
+  std::shared_ptr<ContextsByNode> contextsByNode;
   v8::Local<v8::Array> emptyArray = NewArray(0);
   v8::Local<v8::Integer> zero = NewInteger(0);
 
@@ -80,7 +81,7 @@ class TimeProfileTranslator : ProfileTranslator {
   }
 
   v8::Local<v8::Array> GetLineNumberTimeProfileChildren(
-      const v8::CpuProfileNode* node) {
+      const v8::CpuProfileNode* node) GENERAL_REGS_ONLY {
     unsigned int index = 0;
     v8::Local<v8::Array> children;
     int32_t count = node->GetChildrenCount();
@@ -200,7 +201,7 @@ class TimeProfileTranslator : ProfileTranslator {
   }
 
  public:
-  explicit TimeProfileTranslator(ContextsByNode* nls = nullptr)
+  explicit TimeProfileTranslator(std::shared_ptr<ContextsByNode> nls = nullptr)
       : contextsByNode(nls) {}
 
   v8::Local<v8::Value> TranslateTimeProfile(const v8::CpuProfile* profile,
@@ -230,11 +231,12 @@ class TimeProfileTranslator : ProfileTranslator {
 };
 }  // namespace
 
-v8::Local<v8::Value> TranslateTimeProfile(const v8::CpuProfile* profile,
-                                          bool includeLineInfo,
-                                          ContextsByNode* contextsByNode,
-                                          bool hasCpuTime,
-                                          int64_t nonJSThreadsCpuTime) {
+v8::Local<v8::Value> TranslateTimeProfile(
+    const v8::CpuProfile* profile,
+    bool includeLineInfo,
+    std::shared_ptr<ContextsByNode> contextsByNode,
+    bool hasCpuTime,
+    int64_t nonJSThreadsCpuTime) {
   return TimeProfileTranslator(contextsByNode)
       .TranslateTimeProfile(
           profile, includeLineInfo, hasCpuTime, nonJSThreadsCpuTime);

--- a/bindings/translate-time-profile.hh
+++ b/bindings/translate-time-profile.hh
@@ -24,7 +24,7 @@ namespace dd {
 v8::Local<v8::Value> TranslateTimeProfile(
     const v8::CpuProfile* profile,
     bool includeLineInfo,
-    ContextsByNode* contextsByNode = nullptr,
+    std::shared_ptr<ContextsByNode> contextsByNode = nullptr,
     bool hasCpuTime = false,
     int64_t nonJSThreadsCpuTime = 0);
 


### PR DESCRIPTION
**What does this PR do?**:
Prohibits use of arm64 floating point (FP) registers in some specific functions. For some reason, GCC compiling for arm64 on Linux will sometimes use FP registers to store/load pointers.

**Motivation**:
We see evidence of customer crashes on arm64 Linux, and the only thing they have in common is that they always seem to happen in code that invoked a method by loading `this` of the invoked method in `x0` from some floating point register. We speculate that GCC uses that as an optimization (hey, more free registers!) – as long as it only stores/loads 64-bit values, it's fine. The crashes might be due to some further invoked functions not restoring these.

We can't generally prohibit use of floating point registers in our code (as it completely disables FP arithmetic and it pops up in unusual places, like a float load factor for inlined std::map constructors etc.), but we identified all methods where this "FP reg as pointer storage" tactics were employed by GCC and marked them separately with `__attribute__((target("general-regs-only")))` to prohibit it from using FP regs in them.

Since some of these methods did in fact tried to manipulate floating-point values either directly or indirectly, so we also had to either move those parts out (such is ContextsByNode because of aforementioned inlined float load factor in `std::map` constructor) or converted `async_id` from double to long, as it will always be an integral value.

**How to test the change?**:
We'll release a dev build from this PR, download it, and check whether the use of fp has gone. In local testing on a Linux arm64 VM GCC sadly doesn't reproduce the issue.