### PR TITLE
v5.5.1

### DIFF
--- a/bindings/profilers/wall.cc
+++ b/bindings/profilers/wall.cc
@@ -321,8 +321,9 @@ void SignalHandler::HandleProfilerSignal(int sig,
   auto time_from = Now();
   old_handler(sig, info, context);
   auto time_to = Now();
-  int64_t async_id =
-      static_cast<int64_t>(node::AsyncHooksGetExecutionAsyncId(isolate));
+  int64_t async_id = -1;
+  // don't capture for now until we work out the issues with GC and thread start
+  // static_cast<int64_t>(node::AsyncHooksGetExecutionAsyncId(isolate));
   prof->PushContext(time_from, time_to, cpu_time, async_id);
 }
 #else

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@datadog/pprof",
-  "version": "5.5.0",
+  "version": "5.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@datadog/pprof",
-      "version": "5.5.0",
+      "version": "5.5.1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/pprof",
-  "version": "5.5.0",
+  "version": "5.5.1",
   "description": "pprof support for Node.js",
   "repository": "datadog/pprof-nodejs",
   "main": "out/src/index.js",


### PR DESCRIPTION
Release 5.5.1
===
* Collecting Node Execution Async ID is disabled for now as it causes crashes (#195)