### PR TITLE
Only collect async ID when it's safe to do so

### DIFF
--- a/bindings/profilers/wall.cc
+++ b/bindings/profilers/wall.cc
@@ -291,6 +291,9 @@ void SignalHandler::HandleProfilerSignal(int sig,
     return;
   }
   auto isolate = Isolate::GetCurrent();
+  if (!isolate || isolate->IsDead()) {
+    return;
+  }
   WallProfiler* prof = g_profilers.GetProfiler(isolate);
 
   if (!prof) {

--- a/bindings/profilers/wall.cc
+++ b/bindings/profilers/wall.cc
@@ -315,9 +315,7 @@ void SignalHandler::HandleProfilerSignal(int sig,
   auto time_from = Now();
   old_handler(sig, info, context);
   auto time_to = Now();
-  int64_t async_id = -1;
-  // don't capture for now until we work out the issues with GC and thread start
-  // static_cast<int64_t>(node::AsyncHooksGetExecutionAsyncId(isolate));
+  auto async_id = prof->GetAsyncId(isolate);
   prof->PushContext(time_from, time_to, cpu_time, async_id);
 }
 #else
@@ -492,6 +490,20 @@ std::shared_ptr<ContextsByNode> WallProfiler::GetContextsByNode(
   return contextsByNode;
 }
 
+void GCPrologueCallback(Isolate* isolate,
+                        GCType type,
+                        GCCallbackFlags flags,
+                        void* data) {
+  static_cast<WallProfiler*>(data)->OnGCStart(isolate);
+}
+
+void GCEpilogueCallback(Isolate* isolate,
+                        GCType type,
+                        GCCallbackFlags flags,
+                        void* data) {
+  static_cast<WallProfiler*>(data)->OnGCEnd();
+}
+
 WallProfiler::WallProfiler(std::chrono::microseconds samplingPeriod,
                            std::chrono::microseconds duration,
                            bool includeLines,
@@ -517,6 +529,7 @@ WallProfiler::WallProfiler(std::chrono::microseconds samplingPeriod,
   curContext_.store(&context1_, std::memory_order_relaxed);
   collectionMode_.store(CollectionMode::kNoCollect, std::memory_order_relaxed);
 
+  // TODO: bind to this isolate? Would fix the Dispose(nullptr) issue.
   auto isolate = v8::Isolate::GetCurrent();
   v8::Local<v8::ArrayBuffer> buffer =
       v8::ArrayBuffer::New(isolate, sizeof(uint32_t) * kFieldCount);
@@ -526,6 +539,10 @@ WallProfiler::WallProfiler(std::chrono::microseconds samplingPeriod,
   fields_ = static_cast<uint32_t*>(buffer->GetBackingStore()->Data());
   jsArray_ = v8::Global<v8::Uint32Array>(isolate, jsArray);
   std::fill(fields_, fields_ + kFieldCount, 0);
+
+  gcCount = 0;
+  isolate->AddGCPrologueCallback(&GCPrologueCallback, this);
+  isolate->AddGCEpilogueCallback(&GCEpilogueCallback, this);
 }
 
 WallProfiler::~WallProfiler() {
@@ -538,6 +555,11 @@ void WallProfiler::Dispose(Isolate* isolate) {
     cpuProfiler_ = nullptr;
 
     g_profilers.RemoveProfiler(isolate, this);
+
+    if (isolate != nullptr) {
+      isolate->RemoveGCPrologueCallback(&GCPrologueCallback, this);
+      isolate->RemoveGCEpilogueCallback(&GCEpilogueCallback, this);
+    }
   }
 }
 

--- a/bindings/profilers/wall.hh
+++ b/bindings/profilers/wall.hh
@@ -71,6 +71,7 @@ class WallProfiler : public Nan::ObjectWrap {
   bool workaroundV8Bug_;
   static inline constexpr bool detectV8Bug_ = true;
   bool collectCpuTime_;
+  bool collectAsyncId_;
   bool isMainThread_;
   int v8ProfilerStuckEventLoopDetected_ = 0;
   ProcessCpuClock::time_point startProcessCpuTime_{};
@@ -120,6 +121,7 @@ class WallProfiler : public Nan::ObjectWrap {
                         bool withContexts,
                         bool workaroundV8bug,
                         bool collectCpuTime,
+                        bool collectAsyncId,
                         bool isMainThread);
 
   v8::Local<v8::Value> GetContext(v8::Isolate*);

--- a/bindings/profilers/wall.hh
+++ b/bindings/profilers/wall.hh
@@ -152,29 +152,9 @@ class WallProfiler : public Nan::ObjectWrap {
     return threadCpuStopWatch_.GetAndReset();
   }
 
-  int64_t GetAsyncId(v8::Isolate* isolate) const {
-    if (gcCount > 0) {
-      return gcAsyncId;
-    } else if (isolate->InContext()) {
-      return static_cast<int64_t>(node::AsyncHooksGetExecutionAsyncId(isolate));
-    }
-    return -1;
-  }
-
-  void OnGCStart(v8::Isolate* isolate) {
-    if (gcCount == 0) {
-      gcAsyncId = GetAsyncId(isolate);
-      gcCount = 1;
-    } else {
-      ++gcCount;
-    }
-  }
-
-  void OnGCEnd() {
-    if (--gcCount == 0) {
-      gcAsyncId = -1;
-    }
-  }
+  int64_t GetAsyncId(v8::Isolate* isolate);
+  void OnGCStart(v8::Isolate* isolate);
+  void OnGCEnd();
 
   static NAN_METHOD(New) GENERAL_REGS_ONLY;
   static NAN_METHOD(Start);

--- a/bindings/profilers/wall.hh
+++ b/bindings/profilers/wall.hh
@@ -155,14 +155,18 @@ class WallProfiler : public Nan::ObjectWrap {
   int64_t GetAsyncId(v8::Isolate* isolate) const {
     if (gcCount > 0) {
       return gcAsyncId;
+    } else if (isolate->InContext()) {
+      return static_cast<int64_t>(node::AsyncHooksGetExecutionAsyncId(isolate));
     }
-    return static_cast<int64_t>(node::AsyncHooksGetExecutionAsyncId(isolate));
+    return -1;
   }
 
   void OnGCStart(v8::Isolate* isolate) {
-    if (gcCount++ == 0) {
-      gcAsyncId =
-          static_cast<int64_t>(node::AsyncHooksGetExecutionAsyncId(isolate));
+    if (gcCount == 0) {
+      gcAsyncId = GetAsyncId(isolate);
+      gcCount = 1;
+    } else {
+      ++gcCount;
     }
   }
 

--- a/ts/src/time-profiler.ts
+++ b/ts/src/time-profiler.ts
@@ -66,6 +66,7 @@ export interface TimeProfilerOptions {
   withContexts?: boolean;
   workaroundV8Bug?: boolean;
   collectCpuTime?: boolean;
+  collectAsyncId?: boolean;
 }
 
 const DEFAULT_OPTIONS: TimeProfilerOptions = {
@@ -75,6 +76,7 @@ const DEFAULT_OPTIONS: TimeProfilerOptions = {
   withContexts: false,
   workaroundV8Bug: true,
   collectCpuTime: false,
+  collectAsyncId: false,
 };
 
 export async function profile(options: TimeProfilerOptions = {}) {


### PR DESCRIPTION
**What does this PR do?**:
Reenables async ID collection with guards. Prevents collecting async ID when either GC is ongoing (captures the ID at the GC prologue) or when the isolate has no current context.

**Motivation**:
We want to safely collect async ID.

**Additional Notes**:
Jira: [PROF-11265]


[PROF-11265]: https://datadoghq.atlassian.net/browse/PROF-11265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ