### PR TITLE
Preserve idle samples with zero wall time and no CPU time rollup

### DIFF
--- a/ts/src/v8-types.ts
+++ b/ts/src/v8-types.ts
@@ -38,10 +38,10 @@ export interface ProfileNode {
 }
 
 export interface TimeProfileNodeContext {
-  context: object;
+  context?: object;
   timestamp: bigint; // end of sample taking; in microseconds since epoch
-  cpuTime: number; // cpu time in nanoseconds
-  asyncId: number; // async_hooks.executionAsyncId() at the time of sample taking
+  cpuTime?: number; // cpu time in nanoseconds
+  asyncId?: number; // async_hooks.executionAsyncId() at the time of sample taking
 }
 
 export interface TimeProfileNode extends ProfileNode {

--- a/ts/test/test-time-profiler.ts
+++ b/ts/test/test-time-profiler.ts
@@ -36,13 +36,7 @@ describe('Time Profiler', () => {
     it('should exclude program and idle time', async () => {
       const profile = await time.profile(PROFILE_OPTIONS);
       assert.ok(profile.stringTable);
-      assert.deepEqual(
-        [
-          profile.stringTable.strings!.indexOf('(program)'),
-          profile.stringTable.strings!.indexOf('(idle)'),
-        ],
-        [-1, -1]
-      );
+      assert.equal(profile.stringTable.strings!.indexOf('(program)'), -1);
     });
 
     it('should update state', function () {
@@ -140,7 +134,7 @@ describe('Time Profiler', () => {
           'context.asyncId should be a number'
         );
         const labels: LabelSet = {};
-        for (const [key, value] of Object.entries(context.context)) {
+        for (const [key, value] of Object.entries(context.context ?? {})) {
           if (typeof value === 'string') {
             labels[key] = value;
             if (


### PR DESCRIPTION
**What does this PR do?**:
Changes previous behavior where Node.js profiler dropped idle samples from its final pprof file output. It now keeps them and no longer rolls up their CPU time to the next non-idle sample. It also set their wall time to zero.

**Motivation**:
Keeping idle samples this way has several benefits:
* It gives us evidence that sampling happened.
  * We can use them to break event loop blocking strides that would falsely look continuous if we discarded such samples.
  * We can detect reductions in sampling rate and thus deterioration of profiling quality. It’s currently unclear how would we communicate this to the user.
* It gives us a more realistic view of CPU times. Even a 0,5% of CPU usage while idle will add up to 50% CPU usage over 100 samples (normally, 1s), and previously this accrued to whatever is the next non-idle sample, artificially inflating its CPU use. 

**Additional Notes**:
### A bit of background on idle samples

In Node.js context, _idle samples_ are samples with essentially no stack traces; V8 profiler records a single-frame sample with function name `(idle)` when no JS code is running at the sampling moment. This is due to Node.js not being just a generic JS runtime but one that only invokes code as IO and timer event callbacks. The top level JS program that runs when you invoke it with `node index.js` mostly just sets up some event listeners (a HTTP server typically) and exits. There's not necessarily an active execution (with a stack) at any given time, like for ordinary threaded language runtimes that have a concept of some code always being on stack, just maybe blocked on a lock or IO. Of course Node has that too, it's just that the underlying event loop is in C and as such doesn't register in the V8 profiler until the loop calls into V8 to run an event callback – the V8 callback entry point is always our profiling event horizon.

### The why and how of keeping idle samples

Instead of dropping idle samples, we should keep them. We should also mark their wall time as zero, so they don’t show up as wall time and would really serve mostly as evidence that sampling happened at that time. We should also remove them as wall events from the timeline. However, we would also keep any CPU time ascribed to them. Previously, we would roll their CPU time into the next non-idle sample. This means that even with an idle event loop, we’ll probably see some microseconds of CPU time every 10 miliseconds as belonging to the sample that represents both the libuv thread loop idling as well as the sampling mechanism itself.

Jira: [PROF-11371]

[PROF-11371]: https://datadoghq.atlassian.net/browse/PROF-11371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ