### PR TITLE
v5.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@datadog/pprof",
-  "version": "5.5.1",
+  "version": "5.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@datadog/pprof",
-      "version": "5.5.1",
+      "version": "5.6.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/pprof",
-  "version": "5.5.1",
+  "version": "5.6.0",
   "description": "pprof support for Node.js",
   "repository": "datadog/pprof-nodejs",
   "main": "out/src/index.js",

--- a/ts/src/v8-types.ts
+++ b/ts/src/v8-types.ts
@@ -38,10 +38,10 @@ export interface ProfileNode {
 }
 
 export interface TimeProfileNodeContext {
-  context: object;
+  context?: object;
   timestamp: bigint; // end of sample taking; in microseconds since epoch
-  cpuTime: number; // cpu time in nanoseconds
-  asyncId: number; // async_hooks.executionAsyncId() at the time of sample taking
+  cpuTime?: number; // cpu time in nanoseconds
+  asyncId?: number; // async_hooks.executionAsyncId() at the time of sample taking
 }
 
 export interface TimeProfileNode extends ProfileNode {

--- a/ts/test/test-time-profiler.ts
+++ b/ts/test/test-time-profiler.ts
@@ -36,13 +36,7 @@ describe('Time Profiler', () => {
     it('should exclude program and idle time', async () => {
       const profile = await time.profile(PROFILE_OPTIONS);
       assert.ok(profile.stringTable);
-      assert.deepEqual(
-        [
-          profile.stringTable.strings!.indexOf('(program)'),
-          profile.stringTable.strings!.indexOf('(idle)'),
-        ],
-        [-1, -1]
-      );
+      assert.equal(profile.stringTable.strings!.indexOf('(program)'), -1);
     });
 
     it('should update state', function () {
@@ -140,7 +134,7 @@ describe('Time Profiler', () => {
           'context.asyncId should be a number'
         );
         const labels: LabelSet = {};
-        for (const [key, value] of Object.entries(context.context)) {
+        for (const [key, value] of Object.entries(context.context ?? {})) {
           if (typeof value === 'string') {
             labels[key] = value;
             if (


### PR DESCRIPTION
Release 5.6.0
===
* Idle samples are now preserved with zero wall time and no CPU time rollup to next non-idle (#199)