### PR TITLE
Fix compilation with xcode 16.3

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -83,6 +83,8 @@
                 'xcode_settings': {
                     'OTHER_CFLAGS+': [
                         "-Wno-deprecated-declarations",
+                        "-Wno-cast-function-type-mismatch", # clang17 now warns about casts between incompatible function types and v8 has some of those
+                        "-Wno-unknown-warning-option", # "-Wcast-function-type-mismatch" is not a valid warning option for clang < 17
                         "-Werror",
                         '-std=gnu++20',
                         ],


### PR DESCRIPTION
**What does this PR do?**:

xcode 16.3 ships with clang17 as default compiler. This version of clang warns about casts between incompatible function types, and nan does some of them:
```
include/node/v8-persistent-handle.h:512:26: error: cast from 'typename WeakCallbackInfo<ObjectWrap>::Callback' (aka 'void (*)(const WeakCallbackInfo<ObjectWrap> &)') to 'Callback' (aka 'void (*)(const WeakCallbackInfo<void> &)') converts to incompatible function type [-Werror,-Wcast-function-type-mismatch]
```

This commit adds a -Wno-cast-function-type-mismatch flag to the compiler flags to suppress these warnings (that would otherwise cause errors because of the -Werror flag).
