### PR TITLE
v5.8.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
   asan:
     strategy:
       matrix:
-        version: [16, 18, 20, 22, 23]
+        version: [18, 20, 22, 24]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -23,7 +23,7 @@ jobs:
   valgrind:
     strategy:
       matrix:
-        version: [16, 18, 20, 22, 23]
+        version: [18, 20, 22, 24]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -32,10 +32,11 @@ benchmarks:
     - ./steps/run-benchmarks.sh
   parallel:
     matrix:
-      - MAJOR_NODE_VERSION: 16
       - MAJOR_NODE_VERSION: 18
       - MAJOR_NODE_VERSION: 20
       - MAJOR_NODE_VERSION: 22
+      # TODO: Re-enable this once supports for Node 24 is merged on main
+      # - MAJOR_NODE_VERSION: 24
   artifacts:
     name: "reports"
     paths:

--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -35,8 +35,7 @@ benchmarks:
       - MAJOR_NODE_VERSION: 18
       - MAJOR_NODE_VERSION: 20
       - MAJOR_NODE_VERSION: 22
-      # TODO: Re-enable this once supports for Node 24 is merged on main
-      # - MAJOR_NODE_VERSION: 24
+      - MAJOR_NODE_VERSION: 24
   artifacts:
     name: "reports"
     paths:

--- a/binding.gyp
+++ b/binding.gyp
@@ -83,6 +83,8 @@
                 'xcode_settings': {
                     'OTHER_CFLAGS+': [
                         "-Wno-deprecated-declarations",
+                        "-Wno-cast-function-type-mismatch", # clang17 now warns about casts between incompatible function types and v8 has some of those
+                        "-Wno-unknown-warning-option", # "-Wcast-function-type-mismatch" is not a valid warning option for clang < 17
                         "-Werror",
                         '-std=gnu++20',
                         ],

--- a/bindings/profilers/heap.cc
+++ b/bindings/profilers/heap.cc
@@ -323,7 +323,7 @@ static int CreateTempFile(uv_loop_t& loop, std::string& filepath) {
 }
 
 static void ExportProfile(HeapProfilerState& state) {
-  const int64_t timeoutMs = 5000;
+  const int64_t timeoutMs = 15000;
   uv_loop_t loop;
   int r;
 
@@ -355,6 +355,14 @@ static void ExportProfile(HeapProfilerState& state) {
   options.file = args[0];
   options.args = args.data();
   options.exit_cb = &OnExit;
+  uv_stdio_container_t child_stdio[3];
+  child_stdio[0].flags = UV_IGNORE;
+  child_stdio[1].flags = UV_INHERIT_FD;
+  child_stdio[1].data.fd = 2;
+  child_stdio[2].flags = UV_INHERIT_FD;
+  child_stdio[2].data.fd = 2;
+  options.stdio = child_stdio;
+  options.stdio_count = 3;
   uv_process_t child_req;
   uv_timer_t timer;
   timer.data = &child_req;

--- a/bindings/profilers/heap.cc
+++ b/bindings/profilers/heap.cc
@@ -56,6 +56,11 @@ struct HeapProfilerState {
   explicit HeapProfilerState(v8::Isolate* isolate) : isolate(isolate) {}
 
   ~HeapProfilerState() {
+    auto profiler = isolate->GetHeapProfiler();
+    if (profiler) {
+      profiler->StopSamplingHeapProfiler();
+    }
+
     UninstallNearHeapLimitCallback();
     if (async) {
       // defer deletion of async when uv_close callback is invoked

--- a/bindings/profilers/wall.cc
+++ b/bindings/profilers/wall.cc
@@ -671,7 +671,7 @@ NAN_METHOD(WallProfiler::New) {
 
 NAN_METHOD(WallProfiler::Start) {
   WallProfiler* wallProfiler =
-      Nan::ObjectWrap::Unwrap<WallProfiler>(info.Holder());
+      Nan::ObjectWrap::Unwrap<WallProfiler>(info.This());
 
   if (info.Length() != 0) {
     return Nan::ThrowTypeError("Start must not have any arguments.");
@@ -766,7 +766,7 @@ NAN_METHOD(WallProfiler::Stop) {
   bool restart = info[0].As<Boolean>()->Value();
 
   WallProfiler* wallProfiler =
-      Nan::ObjectWrap::Unwrap<WallProfiler>(info.Holder());
+      Nan::ObjectWrap::Unwrap<WallProfiler>(info.This());
 
   v8::Local<v8::Value> profile;
   auto err = wallProfiler->StopImpl(restart, profile);
@@ -996,27 +996,27 @@ void WallProfiler::SetContext(Isolate* isolate, Local<Value> value) {
 }
 
 NAN_GETTER(WallProfiler::GetContext) {
-  auto profiler = Nan::ObjectWrap::Unwrap<WallProfiler>(info.Holder());
+  auto profiler = Nan::ObjectWrap::Unwrap<WallProfiler>(info.This());
   info.GetReturnValue().Set(profiler->GetContext(info.GetIsolate()));
 }
 
 NAN_SETTER(WallProfiler::SetContext) {
-  auto profiler = Nan::ObjectWrap::Unwrap<WallProfiler>(info.Holder());
+  auto profiler = Nan::ObjectWrap::Unwrap<WallProfiler>(info.This());
   profiler->SetContext(info.GetIsolate(), value);
 }
 
 NAN_GETTER(WallProfiler::SharedArrayGetter) {
-  auto profiler = Nan::ObjectWrap::Unwrap<WallProfiler>(info.Holder());
+  auto profiler = Nan::ObjectWrap::Unwrap<WallProfiler>(info.This());
   info.GetReturnValue().Set(profiler->jsArray_.Get(v8::Isolate::GetCurrent()));
 }
 
 NAN_METHOD(WallProfiler::V8ProfilerStuckEventLoopDetected) {
-  auto profiler = Nan::ObjectWrap::Unwrap<WallProfiler>(info.Holder());
+  auto profiler = Nan::ObjectWrap::Unwrap<WallProfiler>(info.This());
   info.GetReturnValue().Set(profiler->v8ProfilerStuckEventLoopDetected());
 }
 
 NAN_METHOD(WallProfiler::Dispose) {
-  auto profiler = Nan::ObjectWrap::Unwrap<WallProfiler>(info.Holder());
+  auto profiler = Nan::ObjectWrap::Unwrap<WallProfiler>(info.This());
   delete profiler;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@datadog/pprof",
-  "version": "5.7.1",
+  "version": "5.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@datadog/pprof",
-      "version": "5.7.1",
+      "version": "5.8.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -83,5 +83,7 @@
   },
   "engines": {
     "node": ">=16"
-  }
+  },
+  "//": "Temporary fix to make nan@2.22.2 work with Node 24",
+  "postinstall": "sed -i '' 's/^.* Holder() const.*//' ./node_modules/nan/nan_callbacks_12_inl.h"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/pprof",
-  "version": "5.7.1",
+  "version": "5.8.0",
   "description": "pprof support for Node.js",
   "repository": "datadog/pprof-nodejs",
   "main": "out/src/index.js",


### PR DESCRIPTION
Release 5.8.0
===
* Fix compilation with xcode 16.3 (#205)
* Increase timeout for OOM profile export (#206)
* Node 24 support (#207)
* Enable benchmarks on Node 24 (#208)

Other notes:
---
* This release was primarily made for introducing support for Node 24.

JIRA: [PROF-11772]

[PROF-11772]: https://datadoghq.atlassian.net/browse/PROF-11772?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ