### PR TITLE
Use AsyncHooksGetExecutionAsyncId(Context) API on Node 24

### DIFF
--- a/bindings/profilers/wall.cc
+++ b/bindings/profilers/wall.cc
@@ -1022,6 +1022,7 @@ NAN_METHOD(WallProfiler::Dispose) {
 
 double GetAsyncIdNoGC(v8::Isolate* isolate) {
 #if NODE_MAJOR_VERSION >= 24
+  HandleScope scope(isolate);
   auto context = isolate->GetEnteredOrMicrotaskContext();
   return context.IsEmpty() ? -1 : node::AsyncHooksGetExecutionAsyncId(context);
 #else

--- a/bindings/profilers/wall.cc
+++ b/bindings/profilers/wall.cc
@@ -1021,8 +1021,12 @@ NAN_METHOD(WallProfiler::Dispose) {
 }
 
 double GetAsyncIdNoGC(v8::Isolate* isolate) {
-  return isolate->InContext() ? node::AsyncHooksGetExecutionAsyncId(isolate)
-                              : -1;
+#if NODE_MAJOR_VERSION >= 24
+  auto context = isolate->GetEnteredOrMicrotaskContext();
+  return context.IsEmpty() ? -1 : node::AsyncHooksGetExecutionAsyncId(context);
+#else
+  return node::AsyncHooksGetExecutionAsyncId(isolate);
+#endif
 }
 
 double WallProfiler::GetAsyncId(v8::Isolate* isolate) {


### PR DESCRIPTION
Uses `node::AsyncHooksGetExecutionAsyncId(Local<Context>)` API on Node 24 with context obtained through `v8::Isolate::GetEnteredOrMicrotaskContext()`. This API works in GC and also shouldn't cause sporadic crashes on worker threads.

Jira: [PROF-11628]

[PROF-11628]: https://datadoghq.atlassian.net/browse/PROF-11628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ