### PR TITLE
Workaround for v8 crash

### DIFF
--- a/bindings/profilers/heap.cc
+++ b/bindings/profilers/heap.cc
@@ -56,6 +56,11 @@ struct HeapProfilerState {
   explicit HeapProfilerState(v8::Isolate* isolate) : isolate(isolate) {}
 
   ~HeapProfilerState() {
+    auto profiler = isolate->GetHeapProfiler();
+    if (profiler) {
+      profiler->StopSamplingHeapProfiler();
+    }
+
     UninstallNearHeapLimitCallback();
     if (async) {
       // defer deletion of async when uv_close callback is invoked


### PR DESCRIPTION
**What does this PR do?**:

v8 destroys the heap profiler after the heap spaces which can cause crashes: https://github.com/nodejs/node/blob/v24.0.1/deps/v8/src/heap/heap.cc#L6227-L6246

This workaround stops the heap profiler before the heap spaces are destroyed.
