### PR TITLE
Fix invocation of GC callback after freeing the profiler

### DIFF
--- a/bindings/profilers/wall.cc
+++ b/bindings/profilers/wall.cc
@@ -548,14 +548,15 @@ WallProfiler::WallProfiler(std::chrono::microseconds samplingPeriod,
 }
 
 WallProfiler::~WallProfiler() {
-  Dispose(nullptr);
+  Dispose();
 }
 
-void WallProfiler::Dispose(Isolate* isolate) {
+void WallProfiler::Dispose() {
   if (cpuProfiler_ != nullptr) {
     cpuProfiler_->Dispose();
     cpuProfiler_ = nullptr;
 
+    auto isolate = Isolate::GetCurrent();
     g_profilers.RemoveProfiler(isolate, this);
 
     if (isolate != nullptr && collectAsyncId_) {
@@ -896,7 +897,7 @@ Result WallProfiler::StopImpl(bool restart, v8::Local<v8::Value>& profile) {
   v8_profile->Delete();
 
   if (!restart) {
-    Dispose(v8::Isolate::GetCurrent());
+    Dispose();
   } else if (workaroundV8Bug_) {
     waitForSignal(callCount + 1);
     collectionMode_.store(withContexts_ ? CollectionMode::kCollectContexts

--- a/bindings/profilers/wall.hh
+++ b/bindings/profilers/wall.hh
@@ -93,7 +93,7 @@ class WallProfiler : public Nan::ObjectWrap {
   ContextBuffer contexts_;
 
   ~WallProfiler();
-  void Dispose(v8::Isolate* isolate);
+  void Dispose();
 
   // A new CPU profiler object will be created each time profiling is started
   // to work around https://bugs.chromium.org/p/v8/issues/detail?id=11051.


### PR DESCRIPTION
**What does this PR do?**:
Ensures deregistration of GC callbacks always happens when the profiler is destroyed.

**Motivation**:
ASAN [found a case](https://github.com/DataDog/pprof-nodejs/actions/runs/15070648686/job/42365862378?pr=186) where GC callbacks were not deregistered and thus were invoked on a destroyed profiler instance.

**Additional Notes**:
This is implemented by not just passing `nullptr` for `v8::Isolate*` from the destructor into `Dispose` (and thus not activating the GC deregistration) but `Dispose` acquiring the current isolate pointer for itself.
