### PR TITLE
Update min-node-version in release.yml to 18

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       target-name: 'dd_pprof' # target name in binding.gyp
       package-manager: 'npm' # npm or yarn
       cache: true # enable caching of dependencies based on lockfile
-      min-node-version: 16
+      min-node-version: 18
       skip: 'linux-arm,linux-ia32' # skip building for these platforms
 
   publish:


### PR DESCRIPTION
**What does this PR do?**:
Updates min-node-version in release.yml to 18

**Motivation**:
Can't ship a release without fixing this as #215 uses V8 API present in 18+.

JIRA: [SCP-759]


[SCP-759]: https://datadoghq.atlassian.net/browse/SCP-759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ