### PR TITLE
Test new features in more places

### DIFF
--- a/ts/test/worker.ts
+++ b/ts/test/worker.ts
@@ -15,7 +15,8 @@ const withContexts =
 const useCPED =
   satisfies(process.versions.node, '>=24.0.0') &&
   !process.execArgv.includes('--no-async-context-frame');
-const collectAsyncId = satisfies(process.versions.node, '>=24.0.0');
+const collectAsyncId =
+  withContexts && satisfies(process.versions.node, '>=24.0.0');
 
 function createWorker(durationMs: number): Promise<Profile[]> {
   return new Promise((resolve, reject) => {

--- a/ts/test/worker.ts
+++ b/ts/test/worker.ts
@@ -15,6 +15,7 @@ const withContexts =
 const useCPED =
   satisfies(process.versions.node, '>=24.0.0') &&
   !process.execArgv.includes('--no-async-context-frame');
+const collectAsyncId = satisfies(process.versions.node, '>=24.0.0');
 
 function createWorker(durationMs: number): Promise<Profile[]> {
   return new Promise((resolve, reject) => {
@@ -64,6 +65,7 @@ async function main(durationMs: number) {
     withContexts,
     collectCpuTime: withContexts,
     useCPED: useCPED,
+    collectAsyncId: collectAsyncId,
   });
   if (withContexts) {
     time.setContext({});
@@ -108,6 +110,7 @@ async function worker(durationMs: number) {
     withContexts,
     collectCpuTime: withContexts,
     useCPED: useCPED,
+    collectAsyncId: collectAsyncId,
   });
   if (withContexts) {
     time.setContext({});

--- a/ts/test/worker2.ts
+++ b/ts/test/worker2.ts
@@ -1,5 +1,6 @@
 import {parentPort} from 'node:worker_threads';
 import {time} from '../src/index';
+import {satisfies} from 'semver';
 
 const delay = (ms: number) => new Promise(res => setTimeout(res, ms));
 
@@ -13,7 +14,7 @@ time.start({
   intervalMicros: INTERVAL_MICROS,
   withContexts: withContexts,
   collectCpuTime: withContexts,
-  collectAsyncId: false,
+  collectAsyncId: satisfies(process.versions.node, '>=24.0.0'),
 });
 
 parentPort?.on('message', () => {

--- a/ts/test/worker2.ts
+++ b/ts/test/worker2.ts
@@ -9,12 +9,15 @@ const INTERVAL_MICROS = 10000;
 const withContexts =
   process.platform === 'darwin' || process.platform === 'linux';
 
+const collectAsyncId =
+  withContexts && satisfies(process.versions.node, '>=24.0.0');
+
 time.start({
   durationMillis: DURATION_MILLIS,
   intervalMicros: INTERVAL_MICROS,
   withContexts: withContexts,
   collectCpuTime: withContexts,
-  collectAsyncId: satisfies(process.versions.node, '>=24.0.0'),
+  collectAsyncId: collectAsyncId,
 });
 
 parentPort?.on('message', () => {

--- a/ts/test/worker2.ts
+++ b/ts/test/worker2.ts
@@ -9,6 +9,10 @@ const INTERVAL_MICROS = 10000;
 const withContexts =
   process.platform === 'darwin' || process.platform === 'linux';
 
+const useCPED =
+  satisfies(process.versions.node, '>=24.0.0') &&
+  !process.execArgv.includes('--no-async-context-frame');
+
 const collectAsyncId =
   withContexts && satisfies(process.versions.node, '>=24.0.0');
 
@@ -18,6 +22,7 @@ time.start({
   withContexts: withContexts,
   collectCpuTime: withContexts,
   collectAsyncId: collectAsyncId,
+  useCPED: useCPED,
 });
 
 parentPort?.on('message', () => {


### PR DESCRIPTION
**What does this PR do?**:
Enables async ID collection and CPED storage of sample contexts in more tests.

**Motivation**:
We want the features to run as widely as possible in tests. We enable them in worker tests (although we don't check the results – we mostly want to make sure there are no crashes) and also in the larger label testing in `test-time-profiler.ts`

**How to test the change?**:
It's all tests. 

**Additional information**:
The tests uncovered the issue with requesting async ID when there are no free handles for Locals and it needs one Local slot. We added safeguards to bail out of requesting async ID if we know it would trigger allocation of a new array for locals.