### PR TITLE
Reuse `PersistentContextPtr` instances

### DIFF
--- a/bindings/profilers/wall.cc
+++ b/bindings/profilers/wall.cc
@@ -105,7 +105,10 @@ class PersistentContextPtr {
     }
   }
 
-  void MarkDead() { owner->MarkDeadPersistentContextPtr(this); }
+  void MarkDead() {
+    context.reset();
+    owner->MarkDeadPersistentContextPtr(this);
+  }
 
   void RegisterForGC(Isolate* isolate, const Local<Object>& obj) {
     // Register a callback to delete this object when the object is GCed
@@ -114,8 +117,8 @@ class PersistentContextPtr {
         this,
         [](const WeakCallbackInfo<PersistentContextPtr>& data) {
           auto ptr = data.GetParameter();
-          ptr->MarkDead();
           ptr->UnregisterFromGC();
+          ptr->MarkDead();
         },
         WeakCallbackType::kParameter);
   }
@@ -129,6 +132,7 @@ class PersistentContextPtr {
 
 void WallProfiler::MarkDeadPersistentContextPtr(PersistentContextPtr* ptr) {
   deadContextPtrs_.push_back(ptr);
+  liveContextPtrs_.erase(ptr);
 }
 
 // Maximum number of rounds in the GetV8ToEpochOffset
@@ -801,12 +805,9 @@ WallProfiler::WallProfiler(std::chrono::microseconds samplingPeriod,
 #endif  // DD_WALL_USE_CPED
 }
 
-void WallProfiler::UpdateContextCount() {
-  std::atomic_store_explicit(
-      reinterpret_cast<std::atomic<uint32_t>*>(
-          &fields_[WallProfiler::Fields::kCPEDContextCount]),
-      liveContextPtrs_.size(),
-      std::memory_order_relaxed);
+std::atomic<uint32_t>* WallProfiler::GetContextCountPtr() {
+  return reinterpret_cast<std::atomic<uint32_t>*>(
+      &fields_[WallProfiler::Fields::kCPEDContextCount]);
 }
 
 void WallProfiler::Dispose(Isolate* isolate, bool removeFromMap) {
@@ -826,13 +827,21 @@ void WallProfiler::Dispose(Isolate* isolate, bool removeFromMap) {
     node::RemoveEnvironmentCleanupHook(
         isolate, &WallProfiler::CleanupHook, isolate);
 
+    // Delete all live contexts
     for (auto ptr : liveContextPtrs_) {
       ptr->UnregisterFromGC();
       delete ptr;
     }
     liveContextPtrs_.clear();
+
+    // Delete all unused contexts, too
+    for (auto ptr : deadContextPtrs_) {
+      delete ptr;
+    }
     deadContextPtrs_.clear();
-    UpdateContextCount();
+
+    std::atomic_store_explicit(
+        GetContextCountPtr(), 0, std::memory_order_relaxed);
   }
 }
 
@@ -1276,23 +1285,12 @@ void WallProfiler::SetContext(Isolate* isolate, Local<Value> value) {
     return;
   }
 
-  defer {
-    UpdateContextCount();
-  };
-
-  // Clean up dead context pointers
-  for (auto ptr : deadContextPtrs_) {
-    liveContextPtrs_.erase(ptr);
-    delete ptr;
-  }
-  deadContextPtrs_.clear();
-
   auto cped = isolate->GetContinuationPreservedEmbedderData();
   // No Node AsyncContextFrame in this continuation yet
   if (!cped->IsObject()) return;
 
   auto cpedObj = cped.As<Object>();
-  PersistentContextPtr* contextPtr = nullptr;
+  PersistentContextPtr* contextPtr;
   SignalGuard m(setInProgress_);
   auto proxyProto = cpedProxyProto_.Get(isolate);
   if (!proxyProto->StrictEquals(cpedObj->GetPrototype())) {
@@ -1307,7 +1305,14 @@ void WallProfiler::SetContext(Isolate* isolate, Local<Value> value) {
     proxyObj->SetPrototype(v8Ctx, proxyProto).Check();
     proxyObj->Set(v8Ctx, cpedProxySymbol_.Get(isolate), cpedObj).Check();
     // Set up the context pointer in the internal field
-    contextPtr = new PersistentContextPtr(this);
+    if (!deadContextPtrs_.empty()) {
+      contextPtr = deadContextPtrs_.back();
+      deadContextPtrs_.pop_back();
+    } else {
+      contextPtr = new PersistentContextPtr(this);
+      std::atomic_fetch_add_explicit(
+          GetContextCountPtr(), 1, std::memory_order_relaxed);
+    }
     liveContextPtrs_.insert(contextPtr);
     contextPtr->RegisterForGC(isolate, cpedObj);
     proxyObj->SetAlignedPointerInInternalField(0, contextPtr);

--- a/bindings/profilers/wall.hh
+++ b/bindings/profilers/wall.hh
@@ -63,9 +63,8 @@ class WallProfiler : public Nan::ObjectWrap {
   // be deleted when the profiler is disposed.
   std::unordered_set<PersistentContextPtr*> liveContextPtrs_;
   // Context pointers belonging to GC'd CPED objects register themselves here.
-  // They will be deleted and removed from liveContextPtrs_ next time SetContext
-  // is invoked.
-  std::vector<PersistentContextPtr*> deadContextPtrs_;
+  // They will be reused.
+  std::deque<PersistentContextPtr*> deadContextPtrs_;
 
   std::atomic<int> gcCount = 0;
   std::atomic<bool> setInProgress_ = false;
@@ -123,7 +122,7 @@ class WallProfiler : public Nan::ObjectWrap {
   ContextPtr GetContextPtrSignalSafe(v8::Isolate* isolate);
 
   void SetCurrentContextPtr(v8::Isolate* isolate, v8::Local<v8::Value> context);
-  void UpdateContextCount();
+  std::atomic<uint32_t>* GetContextCountPtr();
 
  public:
   /**


### PR DESCRIPTION
**What does this PR do?**:
Instead of freeing `PersistentContextPtr` instances, keeps them in a dequeue and reuses them.

**Motivation**:
It should reduce heap fragmentation. Under a steady load on a service, we should have a roughly constant number of these.
