### PR TITLE
Optimization: allows declaring some labels as low-cardinality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "delay": "^5.0.0",
         "node-gyp-build": "<4.0",
         "p-limit": "^3.1.0",
-        "pprof-format": "^2.1.0",
+        "pprof-format": "^2.2.1",
         "source-map": "^0.7.4"
       },
       "devDependencies": {
@@ -6031,9 +6031,9 @@
       }
     },
     "node_modules/pprof-format": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/pprof-format/-/pprof-format-2.1.0.tgz",
-      "integrity": "sha512-0+G5bHH0RNr8E5hoZo/zJYsL92MhkZjwrHp3O2IxmY8RJL9ooKeuZ8Tm0ZNBw5sGZ9TiM71sthTjWoR2Vf5/xw==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/pprof-format/-/pprof-format-2.2.1.tgz",
+      "integrity": "sha512-p4tVN7iK19ccDqQv8heyobzUmbHyds4N2FI6aBMcXz6y99MglTWDxIyhFkNaLeEXs6IFUEzT0zya0icbSLLY0g==",
       "license": "MIT"
     },
     "node_modules/prelude-ls": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "delay": "^5.0.0",
     "node-gyp-build": "<4.0",
     "p-limit": "^3.1.0",
-    "pprof-format": "^2.1.0",
+    "pprof-format": "^2.2.1",
     "source-map": "^0.7.4"
   },
   "devDependencies": {

--- a/ts/src/time-profiler.ts
+++ b/ts/src/time-profiler.ts
@@ -110,7 +110,8 @@ export function start(options: TimeProfilerOptions = {}) {
 
 export function stop(
   restart = false,
-  generateLabels?: GenerateTimeLabelsFunction
+  generateLabels?: GenerateTimeLabelsFunction,
+  lowCardinalityLabels?: string[]
 ) {
   if (!gProfiler) {
     throw new Error('Wall profiler is not started');
@@ -131,19 +132,20 @@ export function stop(
     gV8ProfilerStuckEventLoopDetected = 0;
   }
 
-  const serialized_profile = serializeTimeProfile(
+  const serializedProfile = serializeTimeProfile(
     profile,
     gIntervalMicros,
     gSourceMapper,
     true,
-    generateLabels
+    generateLabels,
+    lowCardinalityLabels
   );
   if (!restart) {
     gProfiler.dispose();
     gProfiler = undefined;
     gSourceMapper = undefined;
   }
-  return serialized_profile;
+  return serializedProfile;
 }
 
 export function getState() {


### PR DESCRIPTION
**What does this PR do?**:
Optimization: allows declaring some label names as low-cardinality for the time profile serialization. The `Label` objects will be deduplicated for these labels.

**Motivation**:
dd-trace-js emits 3 fixed labels for every sample (thread name, thread ID, thread OS ID.) Because of timeline sample disaggregation, this means roughly 20k label objects are created in memory just for them. With deduplication, we'll only create 3 label objects instead.

**Additional Notes**:
For this to have effect, we need to also land https://github.com/DataDog/pprof-format/pull/26 and release a new `pprof-format` version.
