### PR TITLE
Add profiler metrics

### DIFF
--- a/bindings/profilers/wall.hh
+++ b/bindings/profilers/wall.hh
@@ -43,7 +43,7 @@ class PersistentContextPtr;
 class WallProfiler : public Nan::ObjectWrap {
  public:
   enum class CollectionMode { kNoCollect, kPassThrough, kCollectContexts };
-  enum Fields { kSampleCount, kCPEDContextCount, kFieldCount };
+  enum Fields { kSampleCount, kFieldCount };
 
  private:
   std::chrono::microseconds samplingPeriod_{0};
@@ -122,7 +122,6 @@ class WallProfiler : public Nan::ObjectWrap {
   ContextPtr GetContextPtrSignalSafe(v8::Isolate* isolate);
 
   void SetCurrentContextPtr(v8::Isolate* isolate, v8::Local<v8::Value> context);
-  std::atomic<uint32_t>* GetContextCountPtr();
 
  public:
   /**
@@ -152,6 +151,8 @@ class WallProfiler : public Nan::ObjectWrap {
                    int64_t time_to,
                    int64_t cpu_time,
                    v8::Isolate* isolate);
+  v8::Local<v8::Object> GetMetrics(v8::Isolate*);
+
   Result StartImpl();
   v8::ProfilerId StartInternal();
   Result StopImpl(bool restart, v8::Local<v8::Value>& profile);
@@ -192,6 +193,7 @@ class WallProfiler : public Nan::ObjectWrap {
   static NAN_GETTER(GetContext);
   static NAN_SETTER(SetContext);
   static NAN_GETTER(SharedArrayGetter);
+  static NAN_GETTER(GetMetrics);
 };
 
 }  // namespace dd

--- a/ts/src/time-profiler.ts
+++ b/ts/src/time-profiler.ts
@@ -27,10 +27,10 @@ import {
   getNativeThreadId,
   constants as profilerConstants,
 } from './time-profiler-bindings';
-import {GenerateTimeLabelsFunction} from './v8-types';
+import {GenerateTimeLabelsFunction, TimeProfilerMetrics} from './v8-types';
 import {isMainThread} from 'worker_threads';
 
-const {kSampleCount, kCPEDContextCount} = profilerConstants;
+const {kSampleCount} = profilerConstants;
 
 const DEFAULT_INTERVAL_MICROS: Microseconds = 1000;
 const DEFAULT_DURATION_MILLIS: Milliseconds = 60000;
@@ -169,6 +169,13 @@ export function getContext() {
   return gProfiler.context;
 }
 
+export function getMetrics(): TimeProfilerMetrics {
+  if (!gProfiler) {
+    throw new Error('Wall profiler is not started');
+  }
+  return gProfiler.metrics as TimeProfilerMetrics;
+}
+
 export function isStarted() {
   return !!gProfiler;
 }
@@ -180,7 +187,6 @@ export function v8ProfilerStuckEventLoopDetected() {
 
 export const constants = {
   kSampleCount,
-  kCPEDContextCount,
   GARBAGE_COLLECTION_FUNCTION_NAME,
   NON_JS_THREADS_FUNCTION_NAME,
 };

--- a/ts/src/v8-types.ts
+++ b/ts/src/v8-types.ts
@@ -73,3 +73,8 @@ export interface GenerateTimeLabelsArgs {
 export interface GenerateTimeLabelsFunction {
   (args: GenerateTimeLabelsArgs): LabelSet;
 }
+
+export interface TimeProfilerMetrics {
+  usedAsyncContextCount: number;
+  totalAsyncContextCount: number;
+}

--- a/ts/test/test-time-profiler.ts
+++ b/ts/test/test-time-profiler.ts
@@ -137,6 +137,10 @@ describe('Time Profiler', () => {
       for (let i = 0; i < repeats; ++i) {
         loop();
         enableEndPoint = i % 2 === 0;
+        const metrics = time.getMetrics();
+        const expectedAsyncContextCount = useCPED ? 1 : 0;
+        assert(metrics.totalAsyncContextCount === expectedAsyncContextCount);
+        assert(metrics.usedAsyncContextCount === expectedAsyncContextCount);
         validateProfile(
           time.stop(
             i < repeats - 1,


### PR DESCRIPTION
**What does this PR do?**:
Adds a `getMetrics` method to `time-profiler.ts` as a way to obtain an object with interesting metrics. Currently it is publishing the total and used number of async contexts when using AsyncContextFrame. It replaces the use of the field in the state array, since this information is typically not queried at high velocity.

**Motivation**:
An easily extensible way to publish metrics from the profiler. The ultimate goal is to add these to the runtime section system info for uploaded profiles in dd-trace-js.

**How to test the change?**:
An existing unit test was extended to assert invariants about the currently emitted metrics.

