### PR TITLE
Add Erwan to code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @szegedi @nsavoire @Qard
+* @szegedi @nsavoire @Qard @r1viollet


### PR DESCRIPTION
**What does this PR do?**:
Adds Erwan to CODEOWNERS

**Motivation**:
We have too few code owners to accommodate for PR approval when folks are not available.
