### PR TITLE
Stop using ::set-output

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
       - id: pkg
         run: |
           content=`cat ./package.json | tr '\n' ' '`
-          echo "::set-output name=json::$content"
+          echo "json=$content" >> $GITHUB_OUTPUT
       - run: |
           git tag v${{ fromJson(steps.pkg.outputs.json).version }}
           git push origin v${{ fromJson(steps.pkg.outputs.json).version }}


### PR DESCRIPTION
Use `$GITHUB_OUTPUT` instead

**What does this PR do?**:
Replaces use of `echo "::set-output …"` with `echo "…" >> $GITHUB_OUTPUT`.

**Motivation**:
`echo "::set-output …"` is deprecated, see https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/. This is the change recommended in the deprecation notice.
