### PR TITLE
use release publisher file to release dev tag too

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,29 +43,6 @@ jobs:
       min-node-version: 18
       skip: 'linux-arm,linux-ia32' # skip building for these platforms
 
-  dev_publish:
-    needs: build
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
-    environment: npm
-    permissions:
-      id-token: write # Required for OIDC
-      contents: read
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: actions/download-artifact@v4
-      - uses: actions/setup-node@v3
-        with:
-          node-version: '24'
-          registry-url: 'https://registry.npmjs.org'
-      - run: npm install
-      - id: pkg
-        run: |
-          content=`cat ./package.json | tr '\n' ' '`
-          echo "json=$content" >> $GITHUB_OUTPUT
-      - run: npm version --no-git-tag-version ${{ fromJson(steps.pkg.outputs.json).version }}-$(git rev-parse --short HEAD)+${{ github.run_id }}.${{ github.run_attempt }}
-      - run: npm publish --tag dev
-
   build-successful:
     if: always()
     needs: [build]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Release
 on:
   push:
     branches:
+      - main
       - v[0-9]+.x
 
 jobs:
@@ -15,9 +16,11 @@ jobs:
       min-node-version: 18
       skip: 'linux-arm,linux-ia32' # skip building for these platforms
 
-  publish:
+  publish_release:
     needs: build
     runs-on: ubuntu-latest
+    # release.yml also runs on main for dev publishes, so keep release publishes on version branches only.
+    if: startsWith(github.ref, 'refs/heads/v')
     environment: npm
     permissions:
       id-token: write # Required for OIDC
@@ -43,3 +46,26 @@ jobs:
       - run: |
           git tag v${{ fromJson(steps.pkg.outputs.json).version }}
           git push https://x-access-token:${{ steps.octo-sts.outputs.token }}@github.com/${{ github.repository }}.git v${{ fromJson(steps.pkg.outputs.json).version }}
+
+  publish_dev:
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    environment: npm
+    permissions:
+      id-token: write # Required for OIDC
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/download-artifact@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm install
+      - id: pkg
+        run: |
+          content=`cat ./package.json | tr '\n' ' '`
+          echo "json=$content" >> $GITHUB_OUTPUT
+      - run: npm version --no-git-tag-version ${{ fromJson(steps.pkg.outputs.json).version }}-$(git rev-parse --short HEAD)+${{ github.run_id }}.${{ github.run_attempt }}
+      - run: npm publish --tag dev


### PR DESCRIPTION
**What does this PR do?**:
Update tag dev release to use `release.yml` file on main new commits

**Motivation**:

The recent NPM updates requires to have only one trusted file in order to publish to npm. Updating this file to also publish dev tag on main changes

