### PR TITLE
fix(wall): break SIGPROF self-chain in signal handler install

### DIFF
--- a/bindings/profilers/wall.cc
+++ b/bindings/profilers/wall.cc
@@ -313,11 +313,15 @@ namespace {
 #if DD_WALL_USE_SIGPROF
 class SignalHandler {
  public:
-  static void IncreaseUseCount() {
+  // Returns true on success; false if the previous SIGPROF disposition was
+  // already &HandleProfilerSignal, in which case we cannot chain to v8's
+  // sampler and the caller should surface the failure rather than silently
+  // produce empty profiles.
+  static bool IncreaseUseCount() {
     std::lock_guard<std::mutex> lock(mutex_);
     ++use_count_;
     // Always reinstall the signal handler
-    Install();
+    return Install();
   }
 
   static void DecreaseUseCount() {
@@ -333,24 +337,29 @@ class SignalHandler {
   }
 
  private:
-  static void Install() {
+  static bool Install() {
     struct sigaction sa;
     sa.sa_sigaction = &HandleProfilerSignal;
     sigemptyset(&sa.sa_mask);
     sa.sa_flags = SA_RESTART | SA_SIGINFO | SA_ONSTACK;
     if (installed_) {
       sigaction(SIGPROF, &sa, nullptr);
-    } else {
-      installed_ = (sigaction(SIGPROF, &sa, &old_handler_) == 0);
-      auto prev = old_handler_.sa_sigaction;
-      // Refuse to chain to ourselves. If SIGPROF was already pointing at
-      // HandleProfilerSignal when we ran the install (e.g. because another
-      // SIGPROF user restored its own saved disposition — which it had
-      // captured while we were the active handler — after we Restore()'d),
-      // calling prev would loop forever on the next signal.
-      old_handler_func_.store(prev == &HandleProfilerSignal ? nullptr : prev,
-                              std::memory_order_relaxed);
+      return true;
     }
+    installed_ = (sigaction(SIGPROF, &sa, &old_handler_) == 0);
+    auto prev = old_handler_.sa_sigaction;
+    if (prev == &HandleProfilerSignal) {
+      // SIGPROF was already pointing at HandleProfilerSignal when we ran
+      // the install (e.g. another SIGPROF user restored its own saved
+      // disposition — which it had captured while we were the active
+      // handler — after we Restore()'d). Chaining to prev would loop
+      // forever on the next signal, so refuse. Sampling won't work in
+      // this state because we can't reach v8's SIGPROF sampler.
+      old_handler_func_.store(nullptr, std::memory_order_relaxed);
+      return false;
+    }
+    old_handler_func_.store(prev, std::memory_order_relaxed);
+    return true;
   }
 
   static void Restore() {
@@ -419,7 +428,7 @@ void SignalHandler::HandleProfilerSignal(int sig,
 #else
 class SignalHandler {
  public:
-  static void IncreaseUseCount() {}
+  static bool IncreaseUseCount() { return true; }
   static void DecreaseUseCount() {}
 };
 #endif
@@ -864,7 +873,9 @@ Result WallProfiler::StartImpl() {
     isolate->AddGCEpilogueCallback(&GCEpilogueCallback, this);
   }
 
-  profileId_ = StartInternal();
+  if (auto res = StartInternal(); !res.success) {
+    return res;
+  }
 
   auto collectionMode = withContexts_
                             ? CollectionMode::kCollectContexts
@@ -876,7 +887,7 @@ Result WallProfiler::StartImpl() {
   return {};
 }
 
-v8::ProfilerId WallProfiler::StartInternal() {
+Result WallProfiler::StartInternal() {
   // Reuse the same names for the profiles because strings used for profile
   // names are not released until v8::CpuProfiler object is destroyed.
   // https://github.com/nodejs/node/blob/b53c51995380b1f8d642297d848cab6010d2909c/deps/v8/src/profiler/profile-generator.h#L516
@@ -891,10 +902,21 @@ v8::ProfilerId WallProfiler::StartInternal() {
       // (ie. starting or deopt samples) have been processed, and therefore if
       // SamplingEventsProcessor::ProcessOneSample is stuck on vm_ticks_buffer_.
       withContexts_ || detectV8Bug_);
+  profileId_ = result.id;
 
   // reinstall sighandler on each new upload period
   if (withContexts_ || workaroundV8Bug_) {
-    SignalHandler::IncreaseUseCount();
+    if (!SignalHandler::IncreaseUseCount()) {
+      // SIGPROF was already pointing at HandleProfilerSignal at the moment we
+      // installed (with installed_ == false), so chaining would loop. Without
+      // a working chain, v8's sampler can't fire and we'd silently produce
+      // empty profiles — surface a startup error instead.
+      cpuProfiler_->Stop(profileId_);
+      return Result{
+          "Cannot start wall profiler: SIGPROF disposition was already "
+          "&HandleProfilerSignal at install time. This typically means "
+          "more than one copy of @datadog/pprof is loaded in the process."};
+    }
     fields_[kSampleCount] = 0;
   }
 
@@ -923,7 +945,7 @@ v8::ProfilerId WallProfiler::StartInternal() {
     cpuProfiler_->CollectSample(v8::Isolate::GetCurrent());
   }
 
-  return result.id;
+  return {};
 }
 
 // stopAndCollect(restart, callback): callback result
@@ -1008,7 +1030,10 @@ Result WallProfiler::StopCore(bool restart, ProfileBuilder&& buildProfile) {
   auto startProcessCpuTime = startProcessCpuTime_;
 
   if (restart) {
-    profileId_ = StartInternal();
+    // In restart mode the signal handler is already installed (use_count_
+    // stayed positive across the cycle), so the install can never go through
+    // the else-branch in Install() and IncreaseUseCount() can't fail.
+    StartInternal();
     // record call count to wait for next signal at the end of function
     callCount = noCollectCallCount_.load(std::memory_order_relaxed);
     std::atomic_signal_fence(std::memory_order_acquire);

--- a/bindings/profilers/wall.cc
+++ b/bindings/profilers/wall.cc
@@ -342,7 +342,13 @@ class SignalHandler {
       sigaction(SIGPROF, &sa, nullptr);
     } else {
       installed_ = (sigaction(SIGPROF, &sa, &old_handler_) == 0);
-      old_handler_func_.store(old_handler_.sa_sigaction,
+      auto prev = old_handler_.sa_sigaction;
+      // Refuse to chain to ourselves. If SIGPROF was already pointing at
+      // HandleProfilerSignal when we ran the install (e.g. because another
+      // SIGPROF user restored its own saved disposition — which it had
+      // captured while we were the active handler — after we Restore()'d),
+      // calling prev would loop forever on the next signal.
+      old_handler_func_.store(prev == &HandleProfilerSignal ? nullptr : prev,
                               std::memory_order_relaxed);
     }
   }

--- a/bindings/profilers/wall.cc
+++ b/bindings/profilers/wall.cc
@@ -313,15 +313,19 @@ namespace {
 #if DD_WALL_USE_SIGPROF
 class SignalHandler {
  public:
-  // Returns true on success; false if the previous SIGPROF disposition was
-  // already &HandleProfilerSignal, in which case we cannot chain to v8's
+  // Returns true on success; false if Install() failed, either because
+  // sigaction itself failed or because the previous SIGPROF disposition was
+  // already &HandleProfilerSignal (in which case we cannot chain to v8's
   // sampler and the caller should surface the failure rather than silently
-  // produce empty profiles.
+  // produce empty profiles). On failure use_count_ is left unchanged, so
+  // the caller must NOT balance with DecreaseUseCount().
   static bool IncreaseUseCount() {
     std::lock_guard<std::mutex> lock(mutex_);
+    if (!Install()) {
+      return false;
+    }
     ++use_count_;
-    // Always reinstall the signal handler
-    return Install();
+    return true;
   }
 
   static void DecreaseUseCount() {
@@ -346,19 +350,22 @@ class SignalHandler {
       sigaction(SIGPROF, &sa, nullptr);
       return true;
     }
-    installed_ = (sigaction(SIGPROF, &sa, &old_handler_) == 0);
-    auto prev = old_handler_.sa_sigaction;
-    if (prev == &HandleProfilerSignal) {
+    struct sigaction prev;
+    if (sigaction(SIGPROF, &sa, &prev) != 0) {
+      return false;
+    }
+    if (prev.sa_sigaction == &HandleProfilerSignal) {
       // SIGPROF was already pointing at HandleProfilerSignal when we ran
       // the install (e.g. another SIGPROF user restored its own saved
       // disposition — which it had captured while we were the active
       // handler — after we Restore()'d). Chaining to prev would loop
       // forever on the next signal, so refuse. Sampling won't work in
       // this state because we can't reach v8's SIGPROF sampler.
-      old_handler_func_.store(nullptr, std::memory_order_relaxed);
       return false;
     }
-    old_handler_func_.store(prev, std::memory_order_relaxed);
+    old_handler_ = prev;
+    old_handler_func_.store(prev.sa_sigaction, std::memory_order_relaxed);
+    installed_ = true;
     return true;
   }
 
@@ -874,6 +881,11 @@ Result WallProfiler::StartImpl() {
   }
 
   if (auto res = StartInternal(); !res.success) {
+    // StartInternal may have left v8 cpu profiling running and (if
+    // CreateV8CpuProfiler succeeded) we hold a cpuProfiler_, a g_profilers
+    // entry, and possibly GC pro/epilogue callbacks. Tear them all down so
+    // the caller doesn't observe a half-initialized profiler.
+    Dispose(isolate, true);
     return res;
   }
 
@@ -907,15 +919,17 @@ Result WallProfiler::StartInternal() {
   // reinstall sighandler on each new upload period
   if (withContexts_ || workaroundV8Bug_) {
     if (!SignalHandler::IncreaseUseCount()) {
-      // SIGPROF was already pointing at HandleProfilerSignal at the moment we
-      // installed (with installed_ == false), so chaining would loop. Without
-      // a working chain, v8's sampler can't fire and we'd silently produce
-      // empty profiles — surface a startup error instead.
-      cpuProfiler_->Stop(profileId_);
+      // SIGPROF was already pointing at HandleProfilerSignal at install
+      // time (with installed_ == false), so chaining would loop, or
+      // sigaction itself failed. Without a working chain, v8's sampler
+      // can't fire and we'd silently produce empty profiles — surface a
+      // startup error so the caller can roll back. The just-started v8
+      // cpu profile is left running; the caller is expected to Dispose
+      // the cpuProfiler_, which stops all running profiles.
       return Result{
-          "Cannot start wall profiler: SIGPROF disposition was already "
-          "&HandleProfilerSignal at install time. This typically means "
-          "more than one copy of @datadog/pprof is loaded in the process."};
+          "Cannot start wall profiler: failed to install SIGPROF handler. "
+          "This typically means more than one copy of @datadog/pprof is "
+          "loaded in the process."};
     }
     fields_[kSampleCount] = 0;
   }

--- a/bindings/profilers/wall.hh
+++ b/bindings/profilers/wall.hh
@@ -154,7 +154,7 @@ class WallProfiler : public Nan::ObjectWrap {
   v8::Local<v8::Object> GetMetrics(v8::Isolate*);
 
   Result StartImpl();
-  v8::ProfilerId StartInternal();
+  Result StartInternal();
   template <typename ProfileBuilder>
   Result StopCore(bool restart, ProfileBuilder&& buildProfile);
   Result StopAndCollectImpl(bool restart,


### PR DESCRIPTION
## Summary

Fix infinite recursion in `SignalHandler::HandleProfilerSignal` observed under dd-trace-js + Node.js 20 on x86_64 Linux as ~430 stack frames of `HandleProfilerSignal` calling itself, with each frame paused right after the indirect `callq *%r14` (i.e. the call to `old_handler_func_`).

## Root cause

`SignalHandler::Install()` else-branch captures whatever was the previous SIGPROF disposition into `old_handler_func_`:

```cpp
installed_ = (sigaction(SIGPROF, &sa, &old_handler_) == 0);
old_handler_func_.store(old_handler_.sa_sigaction, std::memory_order_relaxed);
```

If, at that moment, SIGPROF was already pointing at `&HandleProfilerSignal` while `installed_ == false`, we end up storing our own address into `old_handler_func_`, and the next signal delivery loops forever via:

```cpp
auto old_handler = old_handler_func_.load(...);
if (!old_handler) return;
...
old_handler(sig, info, context);  // recurses into HandleProfilerSignal
```

The state `(installed_ == false, SIGPROF == &HandleProfilerSignal)` requires a non-pprof party to write `&HandleProfilerSignal` back into SIGPROF after our `Restore()` cleared `installed_`. Static analysis of single-instance pprof + v8 SIGPROF interaction (`StartInternal` always runs `cpuProfiler_->Start` — which is what may trigger V8's `SignalHandler::IncreaseSamplerCount` → V8.Install — *before* `pprof.IncreaseUseCount`) shows that V8's `old_signal_handler_` can never end up holding `&HandleProfilerSignal`, because V8.Install only runs when V8's process-wide `client_count_` transitions 0→1, and at that point pprof has not yet installed in this lifecycle. So V8.Restore can never write us back into SIGPROF.

The realistic trigger is therefore **two copies of `@datadog/pprof` loaded in the same process** (the dlopen-key for native addons is the file path, so a bundled copy under `node_modules/dd-trace/node_modules/@datadog/pprof` plus a top-level dep at `node_modules/@datadog/pprof` are two distinct instances with independent static state). With that, the sequence

```
A.Install      ; SIGPROF=A, installed_A=true,  pp_old_A=DEFAULT
B.Install      ; SIGPROF=B, installed_B=true,  pp_old_B=A
A.Restore      ; SIGPROF=DEFAULT, installed_A=false
B.Restore      ; SIGPROF=A,       installed_B=false   ← B writes A back
A.Install (2)  ; captures A as its own old_handler        ← self-loop
```

leaves A's `old_handler_func_` pointing at A's own `HandleProfilerSignal`. A non-pprof third-party SIGPROF user that captured pprof while pprof was active and later restores it produces the same shape.

## Fix

Refuse to chain to ourselves in the install path. If the captured previous disposition is `&HandleProfilerSignal`, store `nullptr` in `old_handler_func_` so the handler's existing `if (!old_handler) return;` fast-path kicks in. The signal is dropped instead of recursing — same observable behavior the handler already has when SIGPROF was previously unhandled.

This is a strict improvement: in the two-instance case, the *other* loaded copy still chains to us once via its own `old_handler_func_`, but a single hop is harmless; only the self-loop runs away.

## Test plan

- [x] Builds cleanly with `npm run build`.
- [ ] Existing test suite still passes.
- [ ] Manual reproduction (multi-instance `@datadog/pprof` load and verify no recursion).

Jira: [PROF-14467]

[PROF-14467]: https://datadoghq.atlassian.net/browse/PROF-14467?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ