### PR TITLE
ci: add node 26 to asan and valgrind matrices

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
   asan:
     strategy:
       matrix:
-        version: [18, 20, 22, 24, 25]
+        version: [18, 20, 22, 24, 25, 26]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -23,7 +23,7 @@ jobs:
   valgrind:
     strategy:
       matrix:
-        version: [18, 20, 22, 24, 25]
+        version: [18, 20, 22, 24, 25, 26]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## Summary
- Add Node.js 26 to the `asan` and `valgrind` job matrices in `.github/workflows/build.yml` so CI exercises the latest Node release line.

## Test plan
- [ ] CI passes for the new Node 26 entry on both `asan` and `valgrind` jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)