### PR TITLE
Add Node.js v25 to benchmarks

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -36,8 +36,7 @@ benchmarks:
       - MAJOR_NODE_VERSION: 20
       - MAJOR_NODE_VERSION: 22
       - MAJOR_NODE_VERSION: 24
-      # TODO: Re-enable this once support for Node 25 is merged on main
-      # - MAJOR_NODE_VERSION: 25
+      - MAJOR_NODE_VERSION: 25
   artifacts:
     name: "reports"
     paths:

--- a/benchmark/sirun/runall.sh
+++ b/benchmark/sirun/runall.sh
@@ -9,6 +9,7 @@ if [ -n "${MAJOR_NODE_VERSION:-}" ]; then
         source "${NVM_DIR:-usr/local/nvm}/nvm.sh"
     fi
 
+    nvm install "${MAJOR_NODE_VERSION}"
     nvm use "${MAJOR_NODE_VERSION}"
 
     pushd ../../


### PR DESCRIPTION
**What does this PR do?**:
Add Node.js v25 to benchmarks matrix


**Additional Notes**:
 We already support Node.js v25, updating the benchmark matrix should work

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->


