### PR TITLE
Add Node.js v26 to benchmarks

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -37,6 +37,7 @@ benchmarks:
       - MAJOR_NODE_VERSION: 22
       - MAJOR_NODE_VERSION: 24
       - MAJOR_NODE_VERSION: 25
+      - MAJOR_NODE_VERSION: 26
   artifacts:
     name: "reports"
     paths:


### PR DESCRIPTION
**What does this PR do?**:
Add Node.js v26 to benchmarks matrix.

**Motivation**:
As we aim to support Node.js v26 we also should be able to run benchmarks with Node.js v26


