### PR TITLE
Use node-gyp-build 4 layout for releases too

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
       cache: true # enable caching of dependencies based on lockfile
       min-node-version: 18
       skip: 'linux-arm,linux-ia32' # skip building for these platforms
+      node-gyp-build-major: 4
 
   publish_release:
     needs: build


### PR DESCRIPTION
**What does this PR do?**:
Fixes an omission from #284 that updated `build.yml` for node-gyp-build 4, but unfortunately didn't do it for `release.yml`.

**Motivation**:
Releases break without it.
