### PR TITLE
Fix release tag push and pin actions by SHA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
     environment: npm
     permissions:
       id-token: write # Required for OIDC
-      contents: write
+      contents: read
     steps:
       - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
         id: octo-sts
@@ -33,8 +33,10 @@ jobs:
           scope: DataDog/pprof-nodejs
           policy: self.github.release.push-tags
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: actions/download-artifact@v4
-      - uses: actions/setup-node@v3
+        with:
+          persist-credentials: false # drop GITHUB_TOKEN so the dd-octo-sts token is used for the tag push
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+      - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
@@ -58,8 +60,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: actions/download-artifact@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+      - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
## Summary
- The `publish_release` job's tag push was rejected by the `refs/tags/*` ruleset (see [failed run](https://github.com/DataDog/pprof-nodejs/actions/runs/26151764082/job/76922273183)). Root cause: `actions/checkout` persists `GITHUB_TOKEN` credentials, which take precedence over the dd-octo-sts token we pass in the explicit push URL. Fix matches the working pattern from [sdlc-security-playground](https://github.com/DataDog/sdlc-security-playground/blob/main/.github/workflows/release.yml): set `persist-credentials: false` on checkout and downgrade `contents` permission to `read`.
- Pin `actions/download-artifact` (v4.3.0) and `actions/setup-node` (v3.9.1) by commit SHA in both jobs.

## Test plan
- [ ] Bump version on a `v*.x` branch and confirm the workflow tags + pushes successfully via the dd-octo-sts token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)