### PR TITLE
wall profiler: track live PCPs via an intrusive list

### DIFF
--- a/bindings/profilers/wall.cc
+++ b/bindings/profilers/wall.cc
@@ -108,22 +108,25 @@ void SetContextPtr(ContextPtr& contextPtr,
 
 class PersistentContextPtr : public node::ObjectWrap {
   ContextPtr context;
-  std::unordered_set<PersistentContextPtr*>* live;
+  // Back-pointer to the WallProfiler that created this PCP. Guaranteed to be
+  // a valid pointer whenever pprev_ != nullptr — ~WallProfiler nulls pprev_
+  // on every live PCP before any of them can outlive the profiler.
+  WallProfiler* const profiler_;
+  // Intrusive doubly-linked list, threaded through the WallProfiler's
+  // liveContextPtrHead_. pprev_ points at the slot that currently holds *this
+  // (either the head field or another PCP's next_), enabling O(1) unlink in
+  // ~PCP. pprev_ == nullptr is the "detached" sentinel — set by
+  // ~WallProfiler before deleting us, so our unlink becomes a no-op and we
+  // don't poke at the dying profiler's memory.
+  PersistentContextPtr** pprev_ = nullptr;
+  PersistentContextPtr* next_ = nullptr;
+
+  friend class WallProfiler;
 
  public:
-  PersistentContextPtr(std::unordered_set<PersistentContextPtr*>* live,
-                       Local<Object> wrap)
-      : live(live) {
-    Wrap(wrap);
-  }
+  PersistentContextPtr(WallProfiler* profiler, Local<Object> wrap);
 
-  void Detach() { live = nullptr; }
-
-  ~PersistentContextPtr() {
-    if (live) {
-      live->erase(this);
-    }
-  }
+  ~PersistentContextPtr();
 
   void Set(Isolate* isolate, const Local<Value>& value) {
     SetContextPtr(context, isolate, value);
@@ -135,6 +138,32 @@ class PersistentContextPtr : public node::ObjectWrap {
     return node::ObjectWrap::Unwrap<PersistentContextPtr>(wrap);
   }
 };
+
+PersistentContextPtr::PersistentContextPtr(WallProfiler* profiler,
+                                           Local<Object> wrap)
+    : profiler_(profiler) {
+  Wrap(wrap);
+  // Splice ourselves at the head of profiler's live list.
+  auto** headSlot = profiler->liveContextPtrHeadSlot();
+  next_ = *headSlot;
+  pprev_ = headSlot;
+  if (next_ != nullptr) next_->pprev_ = &next_;
+  *headSlot = this;
+  profiler->recordContextCreate();
+}
+
+PersistentContextPtr::~PersistentContextPtr() {
+  // pprev_ != nullptr means we're still on profiler_'s live list, which means
+  // ~WallProfiler hasn't run yet and the back-pointer is still valid. Unlink
+  // and release the slot in one step. If pprev_ is null, ~WallProfiler is
+  // taking care of us so don't do anything (don't unlink us, and leave its
+  // counter alone as it's about to go away).
+  if (pprev_ != nullptr) {
+    *pprev_ = next_;
+    if (next_ != nullptr) next_->pprev_ = pprev_;
+    profiler_->recordContextRelease();
+  }
+}
 
 inline void* GetAlignedPointerFromInternalField(Object* object, int index) {
 #if NODE_MAJOR_VERSION >= 26
@@ -617,12 +646,21 @@ WallProfiler::~WallProfiler() {
   }
   g_profilers.Remove(this);
 
-  // Delete all live contexts
-  for (auto ptr : liveContextPtrs_) {
-    ptr->Detach();  // so it doesn't invalidate our iterator
-    delete ptr;
+  // Delete every PCP still live in the CPED map. ~PCP would normally unlink
+  // itself via pprev_/next_, but we're tearing down the list we point into —
+  // so null pprev_ first to signal "already detached" and let ~PCP skip the
+  // unlink. (~ObjectWrap will still clear V8's weak callback during delete,
+  // so the dangling internal-field pointer in the wrap object stays inert
+  // even if V8 later GCs the wrap.)
+  auto* p = liveContextPtrHead_;
+  while (p != nullptr) {
+    auto* next = p->next_;
+    p->pprev_ = nullptr;
+    p->next_ = nullptr;
+    delete p;
+    p = next;
   }
-  liveContextPtrs_.clear();
+  liveContextPtrHead_ = nullptr;
 }
 
 void WallProfiler::Dispose(Isolate* isolate) {
@@ -1207,8 +1245,7 @@ Local<Object> WallProfiler::CreateContextHolder(Isolate* isolate,
   // for easy access from JS when cpedKey is an ALS, it can do
   // als.getStore()?.[0];
   wrap->Set(v8Ctx, 0, value).Check();
-  auto contextPtr = new PersistentContextPtr(&liveContextPtrs_, wrap);
-  liveContextPtrs_.insert(contextPtr);
+  auto contextPtr = new PersistentContextPtr(this, wrap);
   contextPtr->Set(isolate, value);
   return wrap;
 }
@@ -1273,7 +1310,7 @@ ContextPtr WallProfiler::GetContextPtr(Isolate* isolate) {
 }
 
 Local<Object> WallProfiler::GetMetrics(Isolate* isolate) {
-  auto usedAsyncContextCount = liveContextPtrs_.size();
+  auto usedAsyncContextCount = liveContextPtrCount();
   auto context = isolate->GetCurrentContext();
   auto metrics = Object::New(isolate);
   metrics

--- a/bindings/profilers/wall.cc
+++ b/bindings/profilers/wall.cc
@@ -113,11 +113,15 @@ class PersistentContextPtr : public node::ObjectWrap {
   // on every live PCP before any of them can outlive the profiler.
   WallProfiler* const profiler_;
   // Intrusive doubly-linked list, threaded through the WallProfiler's
-  // liveContextPtrHead_. pprev_ points at the slot that currently holds *this
-  // (either the head field or another PCP's next_), enabling O(1) unlink in
-  // ~PCP. pprev_ == nullptr is the "detached" sentinel — set by
-  // ~WallProfiler before deleting us, so our unlink becomes a no-op and we
-  // don't poke at the dying profiler's memory.
+  // liveContextPtrHead_. pprev_ is the address of the pointer that currently
+  // references this PCP — &profiler_->liveContextPtrHead_ if we're the head,
+  // &predecessor->next_ otherwise — so by construction *pprev_ == this.
+  // Storing the address-of (rather than the predecessor itself) lets ~PCP
+  // unlink without a head/non-head branch: *pprev_ = next_ followed by
+  // next_->pprev_ = pprev_ does both ends in one shape. pprev_ == nullptr
+  // is the "detached" sentinel — set by ~WallProfiler before deleting us,
+  // so our unlink becomes a no-op and we don't poke at the dying profiler's
+  // memory.
   PersistentContextPtr** pprev_ = nullptr;
   PersistentContextPtr* next_ = nullptr;
 

--- a/bindings/profilers/wall.hh
+++ b/bindings/profilers/wall.hh
@@ -57,9 +57,19 @@ class WallProfiler : public Nan::ObjectWrap {
   int cpedKeyHash_ = 0;
   v8::Global<v8::ObjectTemplate> wrapObjectTemplate_;
 
-  // We track live context pointers in a set to avoid memory leaks. They will
-  // be deleted when the profiler is disposed.
-  std::unordered_set<PersistentContextPtr*> liveContextPtrs_;
+  // The list lets ~WallProfiler delete any PCPs V8 hasn't GC'd yet, so they
+  // don't show up as leaks under LSAN at exit.
+  // PCPs link themselves in at construction and unlink in their destructor.
+  // This used to be an unordered set, but storing two pointers in the PCP is
+  // much cheaper memorywise than the hash set's overhead of buckets and nodes.
+  PersistentContextPtr* liveContextPtrHead_ = nullptr;
+
+  // Number of PersistentContextPtr instances created by this profiler that
+  // are still alive. Incremented in PersistentContextPtr's constructor;
+  // decremented in its destructor when it unlinks from the list (i.e., while
+  // the profiler is still alive). PCPs cleaned up by ~WallProfiler's walk
+  // skip the decrement — the counter is going away with the profiler anyway.
+  std::atomic<size_t> liveContextPtrCount_{0};
 
   std::atomic<int> gcCount = 0;
   std::atomic<bool> setInProgress_ = false;
@@ -174,6 +184,22 @@ class WallProfiler : public Nan::ObjectWrap {
   bool collectCpuTime() const { return collectCpuTime_; }
 
   bool interceptSignal() const { return withContexts_ || workaroundV8Bug_; }
+
+  // Returns the address of the live-PCP list head so a newly constructed PCP
+  // can splice itself in. Only used by PersistentContextPtr's constructor.
+  PersistentContextPtr** liveContextPtrHeadSlot() {
+    return &liveContextPtrHead_;
+  }
+
+  void recordContextCreate() {
+    liveContextPtrCount_.fetch_add(1, std::memory_order_relaxed);
+  }
+  void recordContextRelease() {
+    liveContextPtrCount_.fetch_sub(1, std::memory_order_relaxed);
+  }
+  size_t liveContextPtrCount() const {
+    return liveContextPtrCount_.load(std::memory_order_relaxed);
+  }
 
   int v8ProfilerStuckEventLoopDetected() const {
     return v8ProfilerStuckEventLoopDetected_;

--- a/bindings/profilers/wall.hh
+++ b/bindings/profilers/wall.hh
@@ -69,7 +69,11 @@ class WallProfiler : public Nan::ObjectWrap {
   // decremented in its destructor when it unlinks from the list (i.e., while
   // the profiler is still alive). PCPs cleaned up by ~WallProfiler's walk
   // skip the decrement — the counter is going away with the profiler anyway.
-  std::atomic<size_t> liveContextPtrCount_{0};
+  //
+  // Not atomic: all accesses happen on the isolate's thread (construction via
+  // SetContext from JS, destruction via V8 weak callbacks on the same thread,
+  // metric reads from JS). Signal handler does not touch this field.
+  size_t liveContextPtrCount_ = 0;
 
   std::atomic<int> gcCount = 0;
   std::atomic<bool> setInProgress_ = false;
@@ -191,15 +195,9 @@ class WallProfiler : public Nan::ObjectWrap {
     return &liveContextPtrHead_;
   }
 
-  void recordContextCreate() {
-    liveContextPtrCount_.fetch_add(1, std::memory_order_relaxed);
-  }
-  void recordContextRelease() {
-    liveContextPtrCount_.fetch_sub(1, std::memory_order_relaxed);
-  }
-  size_t liveContextPtrCount() const {
-    return liveContextPtrCount_.load(std::memory_order_relaxed);
-  }
+  void recordContextCreate() { ++liveContextPtrCount_; }
+  void recordContextRelease() { --liveContextPtrCount_; }
+  size_t liveContextPtrCount() const { return liveContextPtrCount_; }
 
   int v8ProfilerStuckEventLoopDetected() const {
     return v8ProfilerStuckEventLoopDetected_;


### PR DESCRIPTION
## Summary

Replaces the `unordered_set<PersistentContextPtr*>` that the wall profiler uses to track live `PersistentContextPtr` (PCP) instances with an intrusive doubly-linked list threaded through the PCPs themselves. Same shutdown semantics — `~WallProfiler` still deletes any PCP that V8 hasn't reclaimed yet — but with materially less per-PCP overhead.

Stacked on top of #322 (thread-local active profiler) and depends on the thread-local already being in place.

## Why

`liveContextPtrs_` exists because, at process exit, V8's CPED map can still hold PCPs that V8's late-shutdown finalizers haven't reached yet. LSAN's leak check fires before those finalizers, so without an explicit cleanup pass each surviving PCP gets reported as a leak (we verified this on `node:22-bookworm` with `--experimental-async-context-frame`: a baseline build with `liveContextPtrs_` removed and *no* replacement leaks ~288 bytes across ~8 PCP allocations per run). The set is a fine tool for the cleanup job, but it carries hash-table overhead unrelated to that job.

## What changed

- New: each `PersistentContextPtr` carries a `WallProfiler* const profiler_`, a `PersistentContextPtr** pprev_`, and a `PersistentContextPtr* next_`. The two list pointers form a standard intrusive doubly-linked list rooted at `WallProfiler::liveContextPtrHead_`.
- `~PersistentContextPtr` unlinks itself when `pprev_ != nullptr`. That predicate also serves as proof that `profiler_` is still valid, so the destructor dereferences it directly to decrement the live counter — no thread-local lookup, no ID compare.
- `~WallProfiler` walks the list, nulls each PCP's `pprev_` (so the soon-to-fire destructor short-circuits the unlink instead of poking at the head pointer in dying memory), then `delete`s each PCP. `~node::ObjectWrap` clears the V8 weak callback during that delete, so the dangling internal-field pointer left behind in the wrap object stays inert even if V8 GCs the wrap later.
- `GetMetrics` reads a plain `size_t liveContextPtrCount_` updated alongside the list link/unlink, replacing the old `liveContextPtrs_.size()`. No atomic needed: every access happens on the isolate's thread (PCP construction from JS, PCP destruction from V8 weak callbacks which run on the isolate thread, metric reads from JS; signal handler doesn't touch it). `usedAsyncContextCount` / `totalAsyncContextCount` keep their existing semantics (both report the live count, just like before).

## Memory savings

Per live PCP, the tracking cost goes from:

|                         | Before (`unordered_set`) | After (intrusive list) |
|-------------------------|--------------------------|------------------------|
| Inside the PCP object   | 8 B (back-pointer to set) | 8 B (back-pointer) + 16 B (two list pointers) = 24 B |
| Outside the PCP object  | ~40 B (hash node + bucket slot in the set) | 0 B |
| **Total**               | **~48 B/PCP**            | **24 B/PCP**           |

A net saving of **~24 bytes per live async context**. The set's per-bucket fixed overhead also goes away, though that's negligible compared to the per-element savings on real workloads.

The list operations are O(1) (insert-at-head, unlink-by-pointer), matching the previous set's amortized characteristics.

## Verification

Ran the project's Linux ASAN+LSAN suite (`npm run test:js-asan`) in a `node:22-bookworm` container with `--node-option=experimental-async-context-frame` so the CPED-mode tests actually execute (without that flag the tests gate themselves out and the code path under test never runs in CI). Compared baseline (this PR reverted) vs patched:

| | Tests | LSAN summaries |
|---|---|---|
| **Baseline** | 95 passing / 1 pending | 40528 B / 75936 B leaked — all V8/Node internal |
| **Patched**  | 95 passing / 1 pending | 40528 B / 79648 B leaked — all V8/Node internal |

Zero references to `PersistentContextPtr`, `WallProfiler`, `dd_pprof.node`, or `wall.cc` in the patched LSAN output. The remaining leaks are pure V8/Node-internal cleanup-on-exit noise, present in identical shape on the baseline (small magnitude differences are noise — V8's final GC state at exit is non-deterministic).

## Test plan

- [x] `npm run build` (macOS Release): clean
- [x] `npm run test:js` (macOS): 96 passing
- [x] `npm run test:js-asan` (Linux container, Node 22 + `--experimental-async-context-frame`): 95 passing, 1 pending, no PCP/WallProfiler/dd_pprof leak reports
- [ ] CI passes