### PR TITLE
fix(time-profiler): serialize before clearing the source mapper in stop()

### DIFF
--- a/ts/src/time-profiler.ts
+++ b/ts/src/time-profiler.ts
@@ -168,10 +168,12 @@ export function stop(
   }
 
   const profile = gProfiler.stop(restart);
+
   if (restart) {
+    // Restart the profiler *before* serializing so the cost of serialization is
+    // captured in the next profile. handleStopRestart() does not dispose of the
+    // source mapper, so the source-map resolution below is unaffected.
     handleStopRestart();
-  } else {
-    handleStopNoRestart();
   }
 
   const serializedProfile = serializeTimeProfile(
@@ -182,6 +184,15 @@ export function stop(
     generateLabels,
     lowCardinalityLabels,
   );
+
+  if (!restart) {
+    // Tear down *after* serializing: handleStopNoRestart() clears gSourceMapper
+    // (and disposes gProfiler), so serializing afterwards would drop source-map
+    // resolution and leave transpiled frames pointing at the generated files
+    // instead of the original sources.
+    handleStopNoRestart();
+  }
+
   return serializedProfile;
 }
 

--- a/ts/test/test-time-profiler.ts
+++ b/ts/test/test-time-profiler.ts
@@ -18,6 +18,8 @@ import * as sinon from 'sinon';
 import {time, getNativeThreadId} from '../src';
 import {profileV2, stopV2} from '../src/time-profiler';
 import * as v8TimeProfiler from '../src/time-profiler-bindings';
+import * as profileSerializer from '../src/profile-serializer';
+import {SourceMapper} from '../src/sourcemapper/sourcemapper';
 import {timeProfile, v8TimeProfile} from './profiles-for-tests';
 import {hrtime} from 'process';
 import {Label, Profile} from 'pprof-format';
@@ -494,6 +496,50 @@ describe('Time Profiler', () => {
 
       sinon.assert.notCalled(timeProfilerStub.start);
       sinon.assert.calledOnce(timeProfilerStub.stop);
+    });
+
+    it('should serialize with the source mapper still set when stopping', () => {
+      // Regression test: stop() used to tear down the profiler state (via
+      // handleStopNoRestart, which clears gSourceMapper) *before* serializing,
+      // so the source mapper passed to start() was dropped and transpiled
+      // frames were left pointing at the generated files instead of the
+      // original sources. The third argument to serializeTimeProfile is the
+      // source mapper; it must still be the one passed to start().
+      const sourceMapper = {} as unknown as SourceMapper;
+      const serializeStub = sinon
+        .stub(profileSerializer, 'serializeTimeProfile')
+        .returns(timeProfile);
+      try {
+        // no-restart path: handleStopNoRestart() clears gSourceMapper, so it
+        // must run after serialization.
+        time.start({
+          intervalMicros: PROFILE_OPTIONS.intervalMicros,
+          sourceMapper,
+        });
+        time.stop();
+        sinon.assert.calledOnce(serializeStub);
+        assert.strictEqual(
+          serializeStub.getCall(0).args[2],
+          sourceMapper,
+          'source mapper dropped on stop()',
+        );
+
+        // restart path: the source mapper must be preserved here too.
+        serializeStub.resetHistory();
+        time.start({
+          intervalMicros: PROFILE_OPTIONS.intervalMicros,
+          sourceMapper,
+        });
+        time.stop(true);
+        assert.strictEqual(
+          serializeStub.getCall(0).args[2],
+          sourceMapper,
+          'source mapper dropped on stop(true)',
+        );
+        time.stop(); // finalize: dispose the restarted profiler
+      } finally {
+        serializeStub.restore();
+      }
     });
   });
 


### PR DESCRIPTION
## Summary

The legacy time-profiler `stop()` serializes the profile **after** tearing down the profiler state, so source maps are silently dropped. CPU profiles taken via `start()` + `stop()` with a `sourceMapper` no longer map transpiled frames (e.g. TypeScript) back to their original sources — they point at the generated `.js` files instead. This is a regression introduced between `5.14.1` and `5.14.3`/`5.14.4`.

## Root cause

In `ts/src/time-profiler.ts`, `stop()` runs `handleStopNoRestart()` (which sets `gSourceMapper = undefined` and disposes the profiler) **before** calling `serializeTimeProfile(profile, gIntervalMicros, gSourceMapper, …)`:

```ts
const profile = gProfiler.stop(restart);
if (restart) { handleStopRestart(); } else { handleStopNoRestart(); } // clears gSourceMapper
const serializedProfile = serializeTimeProfile(profile, gIntervalMicros, gSourceMapper, …); // undefined!
```

Because `gSourceMapper` is `undefined` at serialization time, `serializeTimeProfile` never calls `sourceMapper.mappingInfo(...)`, and frames keep their generated-file locations.

`stopV2()` is unaffected: it serializes inside the `stopAndCollect` callback, which runs while `gSourceMapper` is still set. In `5.14.1`, `stop()` itself used the `stopAndCollect` path, so the mapper was still set at serialization time — hence this is a regression.

## Fix

Move serialization ahead of the teardown so the source mapper is still set, matching `stopV2()` (and the current `main` branch, which already serializes before clearing). The `profile` object returned by the native `stop()` does not depend on the profiler still being alive, so this reordering is safe.

## Reproduction

With `5.14.4`:

```js
const { time, SourceMapper } = require('@datadog/pprof')
const mapper = await SourceMapper.create([appDir])     // appDir contains dist/foo.js + dist/foo.js.map (-> foo.ts)
time.start({ sourceMapper: mapper, lineNumbers: true, intervalMicros: 1000 })
// ... run transpiled code ...
const profile = time.stop()
// profile functions reference dist/foo.js  ❌  (5.14.1: foo.ts ✅)
```

`sourceMapper.mappingInfo` is called 0 times on `5.14.4` vs 26 times on `5.14.1` for the same workload. Using `time.stopV2()` instead of `time.stop()` produces the correctly mapped profile, confirming the diagnosis.

## Test

Added a deterministic regression test in `test-time-profiler.ts` (under `profile (w/ stubs)`): it stubs `serializeTimeProfile` and asserts `stop()` passes the source mapper through. It fails on the current code (`undefined !== {}`) and passes with this fix.

## Notes

Issues are disabled on this repository, so I'm opening this as a PR with the fix. Happy to adjust the approach or test as preferred.
