### PR TITLE
Group patch and minor Dependabot updates for easier approval/merging

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,10 @@ updates:
       - dependencies
       - javascript
       - semver-patch
+    groups:
+      patch-updates:
+        update-types:
+          - "patch"
+      minor-updates:
+        update-types:
+          - "minor"


### PR DESCRIPTION
**What does this PR do?**:
Modifies Dependabot config to allo grouping patch and minor bumps into single PRs (major updates remain individual for closer review.)

**Motivation**:
Save time by not having to deal with individual patch update PRs.
