### PR TITLE
PROF-15218: Update CI actions to Node.js 24 versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,8 +13,8 @@ jobs:
         version: [18, 20, 22, 24, 25, 26]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.version }}
       - run: npm install
@@ -26,8 +26,8 @@ jobs:
         version: [18, 20, 22, 24, 25, 26]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.version }}
       - run: sudo apt-get update && sudo apt-get install valgrind

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
       - run: yarn
       - run: yarn lint

--- a/.github/workflows/package-size.yml
+++ b/.github/workflows/package-size.yml
@@ -15,9 +15,9 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v7
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
       - run: yarn

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,11 +32,14 @@ jobs:
         with:
           scope: DataDog/pprof-nodejs
           policy: self.github.release.push-tags
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false # drop GITHUB_TOKEN so the dd-octo-sts token is used for the tag push
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
-      - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: prebuilds
+          path: prebuilds
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
@@ -59,9 +62,12 @@ jobs:
       id-token: write # Required for OIDC
       contents: read
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
-      - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: prebuilds
+          path: prebuilds
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
GitHub has deprecated the Node.js 20 runtime used by older `actions/*` releases. This bumps the CI actions to versions that run on Node.js 24, matching the versions used by DataDog/action-prebuildify.

## Changes
- `actions/checkout` -> v7
- `actions/setup-node` -> v6
- `actions/download-artifact` -> v7 (release.yml)

The repo uses two pin styles; each file preserves its own:
- build.yml / lint.yml / package-size.yml use floating tags
- release.yml uses SHA-pins with `# vX` comments

## download-artifact name/path fix
`download-artifact` v5+ no longer nests a single nameless artifact under a directory named after it; it extracts directly into the target path. The release publish steps run `npm publish` from cwd and need the native binaries under `./prebuilds/`, so the release jobs now download the merged `prebuilds` artifact explicitly by name into `./prebuilds`.