### PR TITLE
fix(allocations): stop the heap sampling when getting profile

### DIFF
--- a/ts/src/heap-profiler.ts
+++ b/ts/src/heap-profiler.ts
@@ -34,6 +34,7 @@ import {isMainThread} from 'worker_threads';
 
 let enabled = false;
 let heapIntervalBytes = 0;
+let heapStackDepth = 0;
 let startedWithAllocations = false;
 
 /*
@@ -86,12 +87,22 @@ export function profile(
   sourceMapper?: SourceMapper,
   generateLabels?: GenerateAllocationLabelsFunction,
 ): Profile {
-  return convertProfile(
+  const result = convertProfile(
     v8Profile(),
     ignoreSamplePath,
     sourceMapper,
     generateLabels,
   );
+  // In allocation mode V8 keeps every sampled object (live + collected-by-GC)
+  // in an append-only buffer that's only freed by stopSamplingHeapProfiler.
+  // Without this reset, each call to getAllocationProfile re-reads the entire
+  // history, so alloc_* totals grow linearly with wall-clock time and V8's
+  // internal sample buffer leaks for the lifetime of the process.
+  if (startedWithAllocations) {
+    stopSamplingHeapProfiler();
+    startSamplingHeapProfiler(heapIntervalBytes, heapStackDepth, true);
+  }
+  return result;
 }
 
 export function convertProfile(
@@ -193,6 +204,7 @@ export function start(
     );
   }
   heapIntervalBytes = intervalBytes;
+  heapStackDepth = stackDepth;
   startedWithAllocations = allocations;
   startSamplingHeapProfiler(intervalBytes, stackDepth, allocations);
   enabled = true;


### PR DESCRIPTION
**What does this PR do?**:

In `ts/src/heap-profiler.ts`, after each `profile()` call in allocation mode, stop and immediately restart the V8 sampling heap profiler with the original parameters. The stop call frees V8's sample buffer; the restart resumes sampling for the next window.

**Motivation**:

When the heap profiler is started with allocations enabled, V8 retains a record of every sampled allocation. The only V8 API that frees that buffer is `StopSamplingHeapProfiler` and `GetAllocationProfile` does not clear it.

Today the binding never restarts the sampler between collections. Each call to `profile()` re-aggregates the entire history of sampled allocations since the profiler was started, producing two issues:

1. Reported `alloc_*` totals grow ~N× across N consecutive `profile()` calls instead of reflecting the per-window allocation rate.
2. V8's internal sample buffer grows for the lifetime of the process (memory leak)


**Additional Notes**:
Benchmark

**Baseline**

```
  #  pprof_samples   alloc_MiB   inuse_MiB     alloc_objects   ratio_vs_#1
   1              8    5589.60       1.93        366117116     1.00x
   2             10   11202.27       2.43        733927295     2.00x
   3             11   16864.94       2.43       1104955079     3.02x
   4             11   22508.62       2.43       1474818782     4.03x
   5             13   28424.36       2.49       1862485415     5.09x
```

**With the Fix**

```
  #  pprof_samples   alloc_MiB   inuse_MiB     alloc_objects   ratio_vs_#1
   1              6    5656.60       1.93        370557315     1.00x
   2              6    5635.10       2.43        369125338     1.00x
   3              4    5625.60       2.43        368536560     0.99x
   4              5    5589.10       1.93        366109674     0.99x
   5              7    5893.67       1.99        386073436     1.04x
```



