### PR TITLE
fix(test): suppress OpenSSL builtin-compressions LSan leak on Node 26

### DIFF
--- a/suppressions/lsan_suppr.txt
+++ b/suppressions/lsan_suppr.txt
@@ -1,1 +1,2 @@
 leak:CRYPTO_zalloc
+leak:ossl_load_builtin_compressions


### PR DESCRIPTION
## What

Adds an LSan suppression for the OpenSSL builtin-compressions one-time-init leak that is failing the ASAN job on Node.js 26.

## Why

The ASAN (26) job fails with:

```
==XXXX==ERROR: LeakSanitizer: detected memory leaks
Direct leak of 24 byte(s) in 1 object(s) allocated from:
    #1 CRYPTO_malloc
    #2 ossl_load_builtin_compressions
    #3 context_init
    ...
    #12 OPENSSL_init_crypto
    #13 node::InitializeOncePerProcessInternal(...)
```

Node 26's OpenSSL populates a global builtin-compressions list during `OPENSSL_init_crypto` that is never freed at process exit. This is the same class of benign, one-time process-init leak we already suppress via `leak:CRYPTO_zalloc` — but this path allocates via `CRYPTO_malloc` and so isn't matched by the existing rule.

## How

Suppress the specific `ossl_load_builtin_compressions` frame rather than broadening to `CRYPTO_malloc`. `CRYPTO_malloc` is OpenSSL's general-purpose allocator used throughout, so suppressing it would risk masking genuine leaks in crypto code paths; the `ossl_load_builtin_compressions` frame pinpoints exactly this init leak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)