### PR TITLE
fix: Node 26 CI failures — wall profiler cleanup-hook UAF + OpenSSL LSan leak

### DIFF
--- a/bindings/profilers/wall.cc
+++ b/bindings/profilers/wall.cc
@@ -467,7 +467,10 @@ void WallProfiler::Cleanup(Isolate* isolate) {
     if (interceptSignal()) {
       SignalHandler::DecreaseUseCount();
     }
-    Dispose(isolate);
+    // We're running inside the environment cleanup hook itself; Node removes
+    // the hook (and frees its internal record) after we return, so we must not
+    // remove it here — doing so would be a use-after-free. See Dispose().
+    Dispose(isolate, /*removeCleanupHook=*/false);
   }
 }
 
@@ -689,7 +692,7 @@ WallProfiler::~WallProfiler() {
   liveContextPtrHead_ = nullptr;
 }
 
-void WallProfiler::Dispose(Isolate* isolate) {
+void WallProfiler::Dispose(Isolate* isolate, bool removeCleanupHook) {
   if (cpuProfiler_ != nullptr) {
     cpuProfiler_->Dispose();
     cpuProfiler_ = nullptr;
@@ -704,8 +707,10 @@ void WallProfiler::Dispose(Isolate* isolate) {
       isolate->RemoveGCEpilogueCallback(&GCEpilogueCallback, this);
     }
 
-    node::RemoveEnvironmentCleanupHook(
-        isolate, &WallProfiler::CleanupHook, isolate);
+    if (removeCleanupHook) {
+      node::RemoveEnvironmentCleanupHook(
+          isolate, &WallProfiler::CleanupHook, isolate);
+    }
   }
 }
 

--- a/bindings/profilers/wall.hh
+++ b/bindings/profilers/wall.hh
@@ -113,7 +113,14 @@ class WallProfiler : public Nan::ObjectWrap {
   ContextBuffer contexts_;
 
   ~WallProfiler();
-  void Dispose(v8::Isolate* isolate);
+  // removeCleanupHook must be false when Dispose is called from within the
+  // environment cleanup hook (CleanupHook). Node removes the hook itself after
+  // invoking it and dereferences its internal hook record again afterwards, so
+  // calling node::RemoveEnvironmentCleanupHook from inside the hook frees that
+  // record early and leaves Node reading freed memory (use-after-free crash on
+  // worker termination). In all other (still-running) call sites the hook is
+  // live and must be removed so it doesn't fire later against a dead profiler.
+  void Dispose(v8::Isolate* isolate, bool removeCleanupHook = true);
 
   // A new CPU profiler object will be created each time profiling is started
   // to work around https://bugs.chromium.org/p/v8/issues/detail?id=11051.

--- a/suppressions/lsan_suppr.txt
+++ b/suppressions/lsan_suppr.txt
@@ -1,1 +1,2 @@
 leak:CRYPTO_zalloc
+leak:ossl_load_builtin_compressions


### PR DESCRIPTION
Fixes the two Node.js 26 CI failures. They're bundled into one PR because each failure blocks the other's CI from going green, so neither can be merged alone.

---

## 1. `build / alpine-test-26` — SIGSEGV (use-after-free)

### Symptom

`alpine-test-26` crashes with `SIGSEGV` (exit 139) during the `Worker Threads` › `should not crash when worker is terminated` test, which spawns and terminates many workers that each run the wall profiler. Faulting thread:

```
Thread "WorkerThread" received signal SIGSEGV
#0  node::CleanupHookThunkRun(void*)
#1  node::CleanupQueue::Drain()
#2  node::Environment::RunCleanup()
#3  node::FreeEnvironment(node::Environment*)
#4  node::worker::Worker::Run()
```

### Root cause

`WallProfiler` registers an environment cleanup hook (`CleanupHook`) via `node::AddEnvironmentCleanupHook` so it can stop profiling when a worker isolate is terminated without a `beforeExit` notification. On termination, `CleanupHook → Cleanup → Dispose` called `node::RemoveEnvironmentCleanupHook` **for that same hook**.

Node's cleanup-hook trampoline runs the hook and then dereferences its internal hook record *again* to remove the hook itself (disassembly — the fault is at `ldr x0, [x19]` right after the `blr` that calls our callback, and the fault address equals `x19`, the record pointer):

```asm
CleanupHookThunkRun(record):       ; x19 = record
  ldp x1, x0, [x0, #16]            ; x1 = fn_, x0 = arg_
  blr x1                           ; run our CleanupHook  → frees the record
=> ldr x0, [x19]                   ; SIGSEGV: record already freed
  ...
  b   RemoveEnvironmentCleanupHook ; Node removes the hook itself
```

Because our callback removed (and freed) the record mid-execution, Node read freed memory when it returned.

### Fix

Add a `removeCleanupHook` flag to `Dispose` (default `true`). `Cleanup` — which only ever runs from inside `CleanupHook` — passes `false` and lets Node remove the hook itself. The still-running call sites (`StopCore`, `StartImpl` failure path) keep removing it, since there the hook is live and must not fire later against a destroyed profiler.

### Verification

Reproduced and verified in an Alpine/musl Node 26 container under gdb: the worker-termination test crashed within 1–2 runs before the change, and ran **30/30 clean** after it. Covered by the existing `should not crash when worker is terminated` test.

---

## 2. `asan (26)` — LeakSanitizer failure (OpenSSL)

### Symptom

```
==XXXX==ERROR: LeakSanitizer: detected memory leaks
Direct leak of 24 byte(s) in 1 object(s) allocated from:
    #1 CRYPTO_malloc
    #2 ossl_load_builtin_compressions
    ...
    #12 OPENSSL_init_crypto
    #13 node::InitializeOncePerProcessInternal(...)
```

### Root cause & fix

Node 26's OpenSSL populates a global builtin-compressions list during `OPENSSL_init_crypto` that is never freed at process exit. This is the same class of benign one-time process-init leak already suppressed via `leak:CRYPTO_zalloc`, but this path allocates via `CRYPTO_malloc` and so isn't matched. Suppress the specific `ossl_load_builtin_compressions` frame (rather than broadening to `CRYPTO_malloc`, OpenSSL's general allocator, which could mask real leaks).

---

Supersedes #359 (LSan suppression), which is folded in here as a separate commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)