### PR TITLE
fix: drop no-op install script that triggers Yarn build warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "compile": "tsc -p .",
     "fix": "gts fix",
     "format": "clang-format --style file -i --glob='bindings/**/*.{h,hh,cpp,cc}'",
-    "install": "exit 0",
     "lint": "jsgl --local . && gts check && clang-format --style file -n -Werror --glob='bindings/**/*.{h,hh,cpp,cc}'",
     "prepare": "npm run compile && npm run rebuild",
     "pretest:js-asan": "npm run compile && npm run build:asan",

--- a/ts/test/test-no-build-scripts.ts
+++ b/ts/test/test-no-build-scripts.ts
@@ -1,0 +1,14 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('package manifest', () => {
+  it('declares no npm build lifecycle scripts (Yarn Berry YN0007)', () => {
+    const manifest = path.join(__dirname, '..', '..', 'package.json');
+    const pkg = JSON.parse(fs.readFileSync(manifest, 'utf8'));
+    const scripts = pkg.scripts || {};
+    const hooks = ['preinstall', 'install', 'postinstall'];
+    const present = hooks.filter(name => scripts[name] !== undefined);
+    assert.deepStrictEqual(present, []);
+  });
+});


### PR DESCRIPTION
## Summary

Yarn Berry (Plug'n'Play) prints `YN0007: @datadog/pprof must be built` for any dependency that declares an `install`/`preinstall`/`postinstall` script, including the no-op `"install": "exit 0"`. The package ships prebuilt binaries and excludes `binding.gyp` from the published tarball, so a consumer has nothing to build. The script only suppressed npm's implicit `node-gyp rebuild` in the dev tree; CI and the `prepare` script build explicitly.

Dropping it stops the spurious warning for downstream Yarn Berry users, e.g. dd-trace on Vercel/Next.js.

A regression test (`ts/test/test-no-build-scripts.ts`) asserts the manifest declares no build lifecycle scripts.

## Note (out of scope)

`package.json` has a `postinstall` key at the top level (outside `scripts`; the `nan`/Node-24 sed fix). npm and Yarn ignore it there, so it does not trigger YN0007, but it also means that fix never runs. Left untouched here; worth a separate look.

## Test plan

- [ ] CI green (build, asan, valgrind, lint/gts)
- [ ] `yarn add @datadog/pprof` under Yarn Berry no longer prints YN0007

Refs: https://github.com/DataDog/dd-trace-js/issues/5432