### PR TITLE
Fix lint CI: install from lockfile (npm ci) instead of lockless yarn

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,5 +10,5 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
-      - run: yarn
-      - run: yarn lint
+      - run: npm ci
+      - run: npm run lint


### PR DESCRIPTION
## Problem

The `lint` CI job runs `yarn` with **no `yarn.lock`** committed. Yarn ignores `package-lock.json` (npm's lockfile), so it resolves every dependency fresh from the `package.json` version ranges on each run.

`prettier` is not a direct dependency — it's pulled transitively via `gts` (`prettier@^3.6.2`). So CI floats to the newest prettier (currently **3.9.4**), while local development pins **3.8.1** through `package-lock.json`.

prettier **3.9.x changed union-return-type wrapping**, collapsing the leading-`|` multiline form that 3.8.1 emits:

```ts
// 3.8.1 (committed, passes locally)      3.9.4 (CI wants)
:                                          :
  | AllocationProfileNode                    AllocationProfileNode | AllocationProfileNodeWithStats
  | AllocationProfileNodeWithStats
```

Result: `gts check` fails in CI on `heap-profiler.ts` / `heap-profiler-bindings.ts` even though the code is correctly formatted for the pinned prettier — and **the failure never reproduces locally**.

## Fix

Switch the install to `npm ci` (and the script to `npm run lint`) so CI uses the exact `package-lock.json` versions the repo is developed against. This fixes the prettier drift at the root and prevents future lockless-yarn float for every other tool in the lint chain.

## Note

`.github/workflows/package-size.yml` uses the same lockless `yarn` install and has the same latent drift risk; left out of scope here since it isn't currently failing.