### PR TITLE
fix: opt out of node-gyp on install via gypfile:false

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "main": "out/src/index.js",
   "types": "out/src/index.d.ts",
+  "gypfile": false,
   "scripts": {
     "build:asan": "node-gyp configure build --jobs=max --address_sanitizer",
     "build:tsan": "node-gyp configure build --jobs=max --thread_sanitizer",

--- a/ts/test/test-no-build-scripts.ts
+++ b/ts/test/test-no-build-scripts.ts
@@ -3,12 +3,23 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 describe('package manifest', () => {
+  const manifest = path.join(__dirname, '..', '..', 'package.json');
+  const pkg = JSON.parse(fs.readFileSync(manifest, 'utf8'));
+
   it('declares no npm build lifecycle scripts (Yarn Berry YN0007)', () => {
-    const manifest = path.join(__dirname, '..', '..', 'package.json');
-    const pkg = JSON.parse(fs.readFileSync(manifest, 'utf8'));
     const scripts = pkg.scripts || {};
     const hooks = ['preinstall', 'install', 'postinstall'];
     const present = hooks.filter(name => scripts[name] !== undefined);
     assert.deepStrictEqual(present, []);
+  });
+
+  it('opts out of node-gyp on install via gypfile:false (npm implicit rebuild)', () => {
+    // binding.gyp lives in the dev tree (excluded from the published tarball).
+    // Without gypfile:false, npm's publish-time normalization synthesizes
+    // "gypfile": true and "install": "node-gyp rebuild" into the registry
+    // manifest, so consumers run node-gyp rebuild against a missing
+    // binding.gyp and the install fails. Pinning gypfile:false suppresses
+    // that hook while keeping the manifest free of lifecycle scripts.
+    assert.strictEqual(pkg.gypfile, false);
   });
 });


### PR DESCRIPTION
## Summary

Dropping the no-op install script in #363 stopped Yarn Berry's `YN0007` warning, but it handed control to npm's publish-time normalization. With `binding.gyp` in the dev tree (excluded from the tarball) and no `install`/`preinstall` script, npm synthesizes `"gypfile": true` and `"install": "node-gyp rebuild"` into the published manifest. npm consumers then run `node-gyp rebuild` against a `binding.gyp` that isn't in the package, and the install fails — this shipped broken in `5.16.0` (see the linked review, e.g. the pprof-it CI failure).

Setting `"gypfile": false` suppresses that implicit hook while keeping the manifest free of lifecycle scripts, so npm and Yarn Berry both install the prebuilt binaries without a build step. The regression test now pins `gypfile:false` alongside the existing no-lifecycle-scripts assertion.

## Why

`"gypfile": false` is package metadata rather than a lifecycle script, so it does not reintroduce the `YN0007` warning #363 removed. Verified against npm's own normalization (`@npmcli/package-json`): with `binding.gyp` still on disk, the normalized manifest keeps `gypfile: false` and no synthesized `install` script — the exact metadata that was broken in `5.16.0`.

A follow-up patch release is needed since `latest` (`5.16.0`) is currently broken for npm consumers.

Fixes: https://github.com/DataDog/pprof-nodejs/pull/364#pullrequestreview-4638668974