### PR TITLE
feat: add columnNumbers option to control frame column encoding

### DIFF
--- a/ts/src/heap-profiler.ts
+++ b/ts/src/heap-profiler.ts
@@ -23,7 +23,11 @@ import {
   stopSamplingHeapProfiler,
   monitorOutOfMemory as monitorOutOfMemoryImported,
 } from './heap-profiler-bindings';
-import {serializeHeapProfile} from './profile-serializer';
+import {
+  ColumnNumbers,
+  DEFAULT_COLUMN_NUMBERS,
+  serializeHeapProfile,
+} from './profile-serializer';
 import {SourceMapper} from './sourcemapper/sourcemapper';
 import {
   AllocationProfileNode,
@@ -86,12 +90,14 @@ export function profile(
   ignoreSamplePath?: string,
   sourceMapper?: SourceMapper,
   generateLabels?: GenerateAllocationLabelsFunction,
+  columnNumbers: ColumnNumbers = DEFAULT_COLUMN_NUMBERS,
 ): Profile {
   const result = convertProfile(
     v8Profile(),
     ignoreSamplePath,
     sourceMapper,
     generateLabels,
+    columnNumbers,
   );
   // In allocation mode V8 keeps every sampled object (live + collected-by-GC)
   // in an append-only buffer that's only freed by stopSamplingHeapProfiler.
@@ -110,6 +116,7 @@ export function convertProfile(
   ignoreSamplePath?: string,
   sourceMapper?: SourceMapper,
   generateLabels?: GenerateAllocationLabelsFunction,
+  columnNumbers: ColumnNumbers = DEFAULT_COLUMN_NUMBERS,
 ): Profile {
   const allocations = startedWithAllocations;
   const startTimeNanos = Date.now() * 1000 * 1000;
@@ -160,6 +167,7 @@ export function convertProfile(
     sourceMapper,
     generateLabels,
     allocations,
+    columnNumbers,
   );
 }
 
@@ -175,9 +183,16 @@ export function profileV2(
   ignoreSamplePath?: string,
   sourceMapper?: SourceMapper,
   generateLabels?: GenerateAllocationLabelsFunction,
+  columnNumbers: ColumnNumbers = DEFAULT_COLUMN_NUMBERS,
 ): Profile {
   return v8ProfileV2(root => {
-    return convertProfile(root, ignoreSamplePath, sourceMapper, generateLabels);
+    return convertProfile(
+      root,
+      ignoreSamplePath,
+      sourceMapper,
+      generateLabels,
+      columnNumbers,
+    );
   });
 }
 

--- a/ts/src/profile-serializer.ts
+++ b/ts/src/profile-serializer.ts
@@ -78,6 +78,46 @@ function isGeneratedLocation(
   );
 }
 
+/**
+ * Controls how a frame's column number is represented in the emitted profile.
+ * - `'drop'`: omit the column; only the line number is emitted. This is the
+ *   default and matches the historical behavior and standard pprof line
+ *   semantics, so existing consumers see unchanged line numbers.
+ * - `'pack'`: pack the column into the high 32 bits of the line field
+ *   (`column << 32 | line`) — the encoding the Datadog deobfuscation backend
+ *   decodes (the same one the Chrome profile intake uses). Required to
+ *   deobfuscate single-line (bundled/minified) frames, where the column is the
+ *   only discriminator between functions.
+ *
+ * The enum leaves room for a future `'emit'` mode that would populate a real
+ * pprof `Line.column` field once the backend consumes it.
+ */
+export type ColumnNumbers = 'drop' | 'pack';
+
+export const DEFAULT_COLUMN_NUMBERS: ColumnNumbers = 'drop';
+
+/**
+ * Packs a frame's line and column into the single value carried by the pprof
+ * Line.line field: the column in the high 32 bits, the line in the low 32 bits
+ * (matching the backend's JavaScriptProfileUnminifier.decodeLineAndColumn).
+ *
+ * BigInt is used because a minified single-line bundle can place functions at
+ * columns beyond 2**21, which would overflow JavaScript's 32-bit bitwise
+ * operators and, once shifted, exceed the 2**53 safe-integer range.
+ */
+function packLineAndColumn(
+  line: number | undefined,
+  column: number | undefined,
+): number | bigint {
+  if (!line) {
+    return 0;
+  }
+  if (!column) {
+    return line;
+  }
+  return (BigInt(column) << 32n) | BigInt(line);
+}
+
 function requireAllocationStat(
   value: number | undefined,
   field: string,
@@ -107,6 +147,7 @@ function serialize<T extends ProfileNode>(
   stringTable: StringTable,
   ignoreSamplesPath?: string,
   sourceMapper?: SourceMapper,
+  columnNumbers: ColumnNumbers = DEFAULT_COLUMN_NUMBERS,
 ) {
   const samples: Sample[] = [];
   const locations: Location[] = [];
@@ -187,7 +228,10 @@ function serialize<T extends ProfileNode>(
   function getLine(loc: SourceLocation, scriptId?: number): Line {
     return new Line({
       functionId: getFunction(loc, scriptId).id,
-      line: loc.line,
+      line:
+        columnNumbers === 'pack'
+          ? packLineAndColumn(loc.line, loc.column)
+          : loc.line,
     });
   }
 
@@ -386,6 +430,7 @@ export function serializeTimeProfile(
   recomputeSamplingInterval = false,
   generateLabels?: GenerateTimeLabelsFunction,
   lowCardinalityLabels: string[] = [],
+  columnNumbers: ColumnNumbers = DEFAULT_COLUMN_NUMBERS,
 ): Profile {
   // If requested, recompute sampling interval from profile duration and total number of hits,
   // since profile duration should be #hits x interval.
@@ -509,6 +554,7 @@ export function serializeTimeProfile(
     stringTable,
     undefined,
     sourceMapper,
+    columnNumbers,
   );
 
   return new Profile(profile);
@@ -556,6 +602,7 @@ export function serializeHeapProfile(
   sourceMapper?: SourceMapper,
   generateLabels?: GenerateAllocationLabelsFunction,
   allocations = false,
+  columnNumbers: ColumnNumbers = DEFAULT_COLUMN_NUMBERS,
 ): Profile {
   const appendHeapEntryToSamples: AppendEntryToSamples<
     AllocationProfileNode | AllocationProfileNodeWithStats
@@ -642,6 +689,7 @@ export function serializeHeapProfile(
     stringTable,
     ignoreSamplesPath,
     sourceMapper,
+    columnNumbers,
   );
 
   return new Profile(profile);

--- a/ts/src/profile-serializer.ts
+++ b/ts/src/profile-serializer.ts
@@ -101,9 +101,12 @@ export const DEFAULT_COLUMN_NUMBERS: ColumnNumbers = 'drop';
  * Line.line field: the column in the high 32 bits, the line in the low 32 bits
  * (matching the backend's JavaScriptProfileUnminifier.decodeLineAndColumn).
  *
- * BigInt is used because a minified single-line bundle can place functions at
- * columns beyond 2**21, which would overflow JavaScript's 32-bit bitwise
- * operators and, once shifted, exceed the 2**53 safe-integer range.
+ * BigInt is required: JavaScript's bitwise operators are 32-bit, so `column <<
+ * 32` on a plain number is a no-op that returns `column` unchanged. Computing
+ * the pack arithmetically as `column * 2**32 + line` instead loses integer
+ * precision once the column exceeds 2**21 (the product passes 2**53, Number's
+ * safe-integer limit) — and minified single-line bundles routinely have columns
+ * that large.
  */
 function packLineAndColumn(
   line: number | undefined,

--- a/ts/src/time-profiler.ts
+++ b/ts/src/time-profiler.ts
@@ -18,6 +18,8 @@ import {setTimeout} from 'timers/promises';
 
 import {Profile} from 'pprof-format';
 import {
+  ColumnNumbers,
+  DEFAULT_COLUMN_NUMBERS,
   serializeTimeProfile,
   GARBAGE_COLLECTION_FUNCTION_NAME,
   NON_JS_THREADS_FUNCTION_NAME,
@@ -54,6 +56,7 @@ let gProfiler: NativeTimeProfiler | undefined;
 let gStore: AsyncLocalStorage<unknown> | undefined;
 let gSourceMapper: SourceMapper | undefined;
 let gIntervalMicros: Microseconds;
+let gColumnNumbers: ColumnNumbers = DEFAULT_COLUMN_NUMBERS;
 let gV8ProfilerStuckEventLoopDetected = 0;
 
 function handleStopRestart() {
@@ -107,6 +110,15 @@ export interface TimeProfilerOptions {
   collectCpuTime?: boolean;
   collectAsyncId?: boolean;
   useCPED?: boolean;
+
+  /**
+   * Controls how frame column numbers are represented in the serialized
+   * profile. Defaults to `'drop'` (column omitted) to preserve the historical
+   * line-number semantics for existing consumers. Set to `'pack'` to pack the
+   * column into the high 32 bits of the line field for backends that support
+   * it (e.g. Datadog's JS/Node deobfuscation). See {@link ColumnNumbers}.
+   */
+  columnNumbers?: ColumnNumbers;
 }
 
 const DEFAULT_OPTIONS: TimeProfilerOptions = {
@@ -118,6 +130,7 @@ const DEFAULT_OPTIONS: TimeProfilerOptions = {
   collectCpuTime: false,
   collectAsyncId: false,
   useCPED: false,
+  columnNumbers: DEFAULT_COLUMN_NUMBERS,
 };
 
 export async function profile(
@@ -147,6 +160,7 @@ export function start(options: TimeProfilerOptions = {}) {
   gProfiler = new TimeProfiler({...options, CPEDKey: store, isMainThread});
   gSourceMapper = options.sourceMapper;
   gIntervalMicros = options.intervalMicros!;
+  gColumnNumbers = options.columnNumbers ?? DEFAULT_COLUMN_NUMBERS;
   gV8ProfilerStuckEventLoopDetected = 0;
 
   gProfiler.start();
@@ -183,6 +197,7 @@ export function stop(
     true,
     generateLabels,
     lowCardinalityLabels,
+    gColumnNumbers,
   );
 
   if (!restart) {
@@ -220,6 +235,7 @@ export function stopV2(
         true,
         generateLabels,
         lowCardinalityLabels,
+        gColumnNumbers,
       ),
   );
   if (restart) {

--- a/ts/test/test-profile-serializer.ts
+++ b/ts/test/test-profile-serializer.ts
@@ -82,6 +82,85 @@ describe('profile-serializer', () => {
       assert.deepEqual(timeProfileOut, timeProfile);
     });
 
+    it('should drop the column by default and pack it when columnNumbers is "pack"', () => {
+      // Regression test for SCP-1293: a bundled/minified module (e.g. a
+      // Next.js server chunk) emits every function onto generated line 1, so
+      // the column is the only discriminator between functions. The pprof Line
+      // message carries no dedicated column, so with columnNumbers='pack' the
+      // column is packed into the high 32 bits (column<<32 | line) — the
+      // encoding the Datadog deobfuscation backend decodes. The default 'drop'
+      // must leave the plain line untouched for backwards compatibility.
+      const alphaLeaf = {
+        name: 'alpha',
+        scriptName: '/opt/app/.next/server/chunks/58844.js',
+        scriptId: 1,
+        lineNumber: 1,
+        columnNumber: 15665,
+        hitCount: 3,
+        children: [],
+      };
+      const betaLeaf = {
+        name: 'beta',
+        scriptName: '/opt/app/.next/server/chunks/58844.js',
+        scriptId: 1,
+        lineNumber: 1,
+        columnNumber: 14349,
+        hitCount: 2,
+        children: [],
+      };
+      const bundleProfile: TimeProfile = {
+        startTime: 0,
+        endTime: 10 * 1000 * 1000,
+        hasCpuTime: true,
+        nonJSThreadsCpuTime: 0,
+        topDownRoot: {
+          name: '(root)',
+          scriptName: 'root',
+          scriptId: 0,
+          lineNumber: 0,
+          columnNumber: 0,
+          hitCount: 0,
+          children: [alphaLeaf, betaLeaf],
+        },
+      };
+
+      const lineByName = (profile: Profile) => {
+        const m = new Map<string, number | bigint>();
+        for (const location of profile.location!) {
+          const line = location.line![0];
+          const fn = getAndVerifyPresence(
+            profile.function!,
+            line.functionId as number,
+          );
+          m.set(
+            profile.stringTable.strings[fn.name as number] as string,
+            line.line,
+          );
+        }
+        return m;
+      };
+
+      // Default: column dropped, plain generated line 1 retained.
+      const dropped = lineByName(serializeTimeProfile(bundleProfile, 1000));
+      assert.strictEqual(dropped.get('alpha'), 1);
+      assert.strictEqual(dropped.get('beta'), 1);
+
+      // 'pack': column in the high 32 bits, generated line 1 in the low bits.
+      const packed = lineByName(
+        serializeTimeProfile(
+          bundleProfile,
+          1000,
+          undefined,
+          false,
+          undefined,
+          [],
+          'pack',
+        ),
+      );
+      assert.strictEqual(BigInt(packed.get('alpha')!), (15665n << 32n) | 1n);
+      assert.strictEqual(BigInt(packed.get('beta')!), (14349n << 32n) | 1n);
+    });
+
     it('should omit non-jS threads CPU time when profile has no CPU time', () => {
       const timeProfile: TimeProfile = {
         startTime: 0,

--- a/ts/test/test-profile-serializer.ts
+++ b/ts/test/test-profile-serializer.ts
@@ -277,6 +277,33 @@ describe('profile-serializer', () => {
       const heapProfileOut = serializeHeapProfile(v8HeapProfile, 0, 512 * 1024);
       assert.deepEqual(heapProfileOut, heapProfile);
     });
+    it('should pack the column into the emitted line when columnNumbers is "pack"', () => {
+      // v8HeapProfile frames all use columnNumber 5; with 'pack' each emitted
+      // line must carry that column in its high 32 bits.
+      const packed = serializeHeapProfile(
+        v8HeapProfile,
+        0,
+        512 * 1024,
+        undefined,
+        undefined,
+        undefined,
+        false,
+        'pack',
+      );
+      for (const location of packed.location!) {
+        const line = location.line![0];
+        assert.strictEqual(
+          BigInt(line.line) >> 32n,
+          5n,
+          'column packed into high bits',
+        );
+      }
+      // Default still drops the column (plain line, no high bits).
+      const dropped = serializeHeapProfile(v8HeapProfile, 0, 512 * 1024);
+      for (const location of dropped.location!) {
+        assert.strictEqual(BigInt(location.line![0].line) >> 32n, 0n);
+      }
+    });
     it('should produce expected profile when there is anonymous function', () => {
       const heapProfileOut = serializeHeapProfile(
         v8AnonymousFunctionHeapProfile,


### PR DESCRIPTION
## What

Adds a `columnNumbers` option controlling how a frame's column is represented in the serialized profile:

- **`'drop'` (default)** — omit the column, emit the plain line. Preserves today's behavior, so existing pprof-nodejs consumers (including external ones) see unchanged line numbers.
- **`'pack'`** — pack the column into the high 32 bits of the line field (`column << 32 | line`), the encoding the Datadog deobfuscation backend decodes (the same one the Chrome profile intake uses).

The enum leaves room for a future `'emit'` mode that would populate a real pprof `Line.column` field once the backend consumes it (see DataDog/pprof-format#80).

## Why

pprof's `Line` message historically had no column field, so pprof-nodejs dropped the column entirely. For bundled/minified **server** code (e.g. Next.js server chunks) the whole module is emitted on generated **line 1**, so the column is the only discriminator between functions. When source maps aren't deployed locally (`dd:has-missing-map-files`), the raw profile is shipped to the backend for deobfuscation — and without a column every frame collapses to line 1 and can't be resolved.

Making this opt-in (default `'drop'`) avoids surprising other pprof-nodejs consumers with "huge" packed line numbers. `dd-trace-js` opts in via `columnNumbers: 'pack'` (separate follow-up).

## Changes

- `ts/src/profile-serializer.ts` — `ColumnNumbers` type (`'drop' | 'pack'`), `DEFAULT_COLUMN_NUMBERS = 'drop'`, and a `packLineAndColumn` helper (BigInt, since minified single-line bundles place functions at columns beyond `2**21`). `getLine` packs only when `columnNumbers === 'pack'`. Threaded through `serialize` / `serializeTimeProfile` / `serializeHeapProfile`.
- `ts/src/time-profiler.ts` — `columnNumbers` on `TimeProfilerOptions` (default `'drop'`), stored on start and passed to the serializer in `stop`/`stopV2`.
- `ts/test/test-profile-serializer.ts` — regression test asserting the default drops the column (plain line retained) and `'pack'` packs `column<<32 | line` (columns 15665/14349).

No fixtures changed — the default preserves existing output.

## Backend

No backend or protobuf change needed: `profiling-backend`'s `JavaScriptProfileUnminifier.decodeLineAndColumn` already unpacks `column << 32 | line` (used today for the Chrome intake), and a non-packed small line decodes to column 0.

## Testing

`test-profile-serializer` / `test-profile-encoder` / `test-sourcemapper` — **50 passing**. `gts check` clean.

## Follow-ups

- `dd-trace-js`: pass `columnNumbers: 'pack'` when starting the wall profiler.
- Optional `'emit'` mode + DataDog/pprof-format#80 (real `Line.column`) once the backend reads it.

Jira: [PROF-15467]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PROF-15467]: https://datadoghq.atlassian.net/browse/PROF-15467?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ