### PR TITLE
chore: ignore TypeScript major-version bumps in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,12 @@ updates:
     ignore:
       # Internal dependencies that we update manually
       - dependency-name: "pprof-format"
+      # TypeScript 7 (the native port) is not yet supported by typescript-eslint
+      # (and therefore gts), so major bumps break `npm run lint`.
+      # See https://github.com/typescript-eslint/typescript-eslint/issues/10940
+      # Re-enable once typescript-eslint ships TS >=7 support.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
     versioning-strategy: "increase"
     labels:
       - dependabot


### PR DESCRIPTION
## What

Adds a dependabot `ignore` rule for TypeScript **major-version** updates.

## Why

Dependabot #374 tried to bump `typescript` from 6.0.3 → 7.0.2. TypeScript 7 is the new native (Go) port, and it is **not yet supported by `typescript-eslint`** — and therefore not by `gts`, which the lint job runs (`npm run lint` → `gts check`). The latest published `typescript-eslint` (8.65.0) still declares a peer dependency of `typescript >=4.8.4 <6.1.0`, so the lint job fails with:

```
Error: typescript-eslint does not support TS 7.0.
```

Support for TS ≥7 is tracked upstream but not yet shipped:
https://github.com/typescript-eslint/typescript-eslint/issues/10940

Until that lands, major `typescript` bumps can't pass CI, so this rule stops dependabot from repeatedly opening them. Minor/patch bumps within TS 6 are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)