### PR TITLE
add 'emit' column-numbers mode using pprof-format Line.column

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "node-gyp-build": "^4.8.4",
-        "pprof-format": "^2.2.1",
+        "pprof-format": "^2.3.0",
         "source-map": "^0.8.0"
       },
       "devDependencies": {
@@ -5062,9 +5062,9 @@
       }
     },
     "node_modules/pprof-format": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/pprof-format/-/pprof-format-2.2.1.tgz",
-      "integrity": "sha512-p4tVN7iK19ccDqQv8heyobzUmbHyds4N2FI6aBMcXz6y99MglTWDxIyhFkNaLeEXs6IFUEzT0zya0icbSLLY0g==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pprof-format/-/pprof-format-2.3.0.tgz",
+      "integrity": "sha512-ovChRLoV4H3k0zKWq0AXewtnuPGskzBLjBPmF2N0DZu+H65PYuo51+6e/1GTb8Olm7oC0xvhhLdqPL4/XhCl4A==",
       "license": "MIT"
     },
     "node_modules/prelude-ls": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "node-gyp-build": "^4.8.4",
-    "pprof-format": "^2.2.1",
+    "pprof-format": "^2.3.0",
     "source-map": "^0.8.0"
   },
   "devDependencies": {

--- a/ts/src/profile-serializer.ts
+++ b/ts/src/profile-serializer.ts
@@ -87,12 +87,18 @@ function isGeneratedLocation(
  *   (`column << 32 | line`) — the encoding the Datadog deobfuscation backend
  *   decodes (the same one the Chrome profile intake uses). Required to
  *   deobfuscate single-line (bundled/minified) frames, where the column is the
- *   only discriminator between functions.
- *
- * The enum leaves room for a future `'emit'` mode that would populate a real
- * pprof `Line.column` field once the backend consumes it.
+ *   only discriminator between functions. Only frames whose source map was
+ *   declared but missing locally are packed.
+ * - `'emit'`: like `'pack'`, but records the column in the dedicated pprof
+ *   `Line.column` field instead of packing it into the line field, so the line
+ *   field stays standards-compliant and the two concerns are cleanly separated.
+ *   Scoped to the same frames as `'pack'` — only those whose source map was
+ *   declared but missing locally, i.e. the frames bound for server-side
+ *   unminification. The Datadog backend performs the `column << 32 | line`
+ *   packing itself (for Node.js profiles) when it consumes the column field.
+ *   Requires pprof-format >= 2.3.0, the version that added `Line.column`.
  */
-export type ColumnNumbers = 'drop' | 'pack';
+export type ColumnNumbers = 'drop' | 'pack' | 'emit';
 
 export const DEFAULT_COLUMN_NUMBERS: ColumnNumbers = 'drop';
 
@@ -158,6 +164,7 @@ function serialize<T extends ProfileNode>(
   const functionIdMap = new Map<string, number>();
   const locationIdMap = new Map<string, number>();
   const packColumns = columnNumbers === 'pack';
+  const emitColumns = columnNumbers === 'emit';
 
   let hasMissingMapFiles = false;
 
@@ -230,15 +237,23 @@ function serialize<T extends ProfileNode>(
   }
 
   function getLine(loc: SourceLocation, scriptId?: number): Line {
-    // Only pack the column for frames whose source map was declared but missing
-    // locally — i.e. exactly the frames that will be sent for server-side
-    // unminification (the same condition that sets dd:has-missing-map-files).
-    // Locally-resolved frames keep their plain line, so packed values never
-    // reach profiles that skip server-side unminification.
-    const packColumn = packColumns && loc.missingMapFile === true;
+    // Both 'pack' and 'emit' carry the column only for frames whose source map
+    // was declared but missing locally — i.e. exactly the frames bound for
+    // server-side unminification (the same condition that sets
+    // dd:has-missing-map-files). Locally-resolved frames keep a plain line and
+    // no column, so column data never reaches profiles that skip server-side
+    // unminification.
+    const carryColumn = loc.missingMapFile === true;
     return new Line({
       functionId: getFunction(loc, scriptId).id,
-      line: packColumn ? packLineAndColumn(loc.line, loc.column) : loc.line,
+      // 'pack' encodes the column into the high 32 bits of the line field.
+      line:
+        packColumns && carryColumn
+          ? packLineAndColumn(loc.line, loc.column)
+          : loc.line,
+      // 'emit' records the column in the dedicated pprof Line.column field
+      // instead; the backend does the line/column packing itself.
+      column: emitColumns && carryColumn ? loc.column : undefined,
     });
   }
 

--- a/ts/src/time-profiler.ts
+++ b/ts/src/time-profiler.ts
@@ -115,8 +115,9 @@ export interface TimeProfilerOptions {
    * Controls how frame column numbers are represented in the serialized
    * profile. Defaults to `'drop'` (column omitted) to preserve the historical
    * line-number semantics for existing consumers. Set to `'pack'` to pack the
-   * column into the high 32 bits of the line field for backends that support
-   * it (e.g. Datadog's JS/Node deobfuscation). See {@link ColumnNumbers}.
+   * column into the high 32 bits of the line field, or `'emit'` to populate the
+   * dedicated pprof `Line.column` field, for backends that support it (e.g.
+   * Datadog's JS/Node deobfuscation). See {@link ColumnNumbers}.
    */
   columnNumbers?: ColumnNumbers;
 }

--- a/ts/test/test-profile-serializer.ts
+++ b/ts/test/test-profile-serializer.ts
@@ -497,6 +497,48 @@ describe('profile-serializer', () => {
       );
     });
 
+    it('emits the real column in the pprof Line.column field and keeps the line plain when columnNumbers is "emit"', () => {
+      // 'emit' never packs: the line field stays plain and the generated column
+      // (1) is written to the dedicated pprof Line.column field. The backend
+      // performs the line/column packing itself for Node.js profiles.
+      const profile = serializeTimeProfile(
+        makeSingleNodeTimeProfile(missingJsPath),
+        1000,
+        sourceMapper,
+        false,
+        undefined,
+        [],
+        'emit',
+      );
+      assertHasMissingMapToken(profile);
+      const line = profile.location![0].line![0];
+      assert.strictEqual(BigInt(line.line), 1n);
+      assert.strictEqual(BigInt(line.column), 1n);
+    });
+
+    it('does not carry a column under "emit" for a frame with no missing map', () => {
+      // 'emit' is scoped to the same frames as 'pack': only those whose map was
+      // declared but missing locally. With no source mapper the frame is neither
+      // resolved nor flagged missing, so no column is emitted (Line.column
+      // defaults to 0) and the line stays plain.
+      const profile = serializeTimeProfile(
+        makeSingleNodeTimeProfile(missingJsPath),
+        1000,
+        undefined,
+        false,
+        undefined,
+        [],
+        'emit',
+      );
+      assert.ok(
+        !profile.comment || profile.comment.length === 0,
+        'expected no missing-map token without a source mapper',
+      );
+      const line = profile.location![0].line![0];
+      assert.strictEqual(BigInt(line.line), 1n);
+      assert.strictEqual(BigInt(line.column), 0n);
+    });
+
     it('leaves a missing-map frame line plain under the default "drop"', () => {
       const profile = serializeTimeProfile(
         makeSingleNodeTimeProfile(missingJsPath),


### PR DESCRIPTION
**What does this PR do?**:
Adds a new `'emit'` value to the `columnNumbers` option (alongside the existing `'drop'` and `'pack'`). In `'emit'` mode the serializer records the frame's column in the dedicated pprof `Line.column` field rather than packing it into the high 32 bits of the line field. This requires `pprof-format >= 2.3.0` (the version that added `Line.column`), so the dependency is bumped from `^2.2.1` to `^2.3.0`.

Like `'pack'`, `'emit'` only carries a column for frames whose source map was declared but is missing locally — i.e. exactly the frames bound for server-side unminification (the same condition that sets `dd:has-missing-map-files`). Locally-resolved frames keep a plain line and no column, so column data never reaches profiles that skip server-side unminification.

**Motivation**:
Server-side deobfuscation of minified Node.js/Next.js profiles needs the column number to discriminate between functions on a single (bundled) line. The existing `'pack'` mode encodes the column into the line field, but that produces a non-standards-compliant line value. `'emit'` keeps the two concerns cleanly separated: the pprof file carries a real `Line.column`, and the Datadog backend does the `column << 32 | line` packing itself for Node.js profiles when it consumes the column field. The backend-side column parsing/packing has already landed.

**Additional Notes**:
`'drop'` remains the default, so existing consumers are unaffected. This is purely additive.

**How to test the change?**:
Covered by unit tests in `ts/test/test-profile-serializer.ts`:
- `'emit'` populates the real `Line.column` field and keeps the line plain for a frame with a missing source map.
- `'emit'` carries no column for a frame with no missing map.

Full serializer suite: 24 passing. `gts check` clean (one pre-existing unrelated warning in `otel-thread-ctx.ts`).

Jira: [PROF-15672]

[PROF-15672]: https://datadoghq.atlassian.net/browse/PROF-15672?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ