### PR TITLE
fix(heap): don't assume a per-isolate state exists

### DIFF
--- a/bindings/profilers/heap.cc
+++ b/bindings/profilers/heap.cc
@@ -370,6 +370,21 @@ size_t NearHeapLimit(void* data,
   auto isolate = v8::Isolate::GetCurrent();
   auto state = PerIsolateData::For(isolate)->GetHeapProfilerState();
 
+  if (!state) {
+    // StopSamplingHeapProfiler uninstalls us before dropping the state, so
+    // normally this cannot happen. The gap is the other destruction path: a
+    // shared_ptr copy taken by an in-flight NearHeapLimit or InterruptCallback
+    // can outlive the per-isolate slot — the OOM JS callback calling
+    // process.exit() erases PerIsolateData while InterruptCallback still holds
+    // a reference, so ~HeapProfilerState never runs to uninstall us. Decline
+    // and let V8 do its normal OOM handling.
+    //
+    // Deliberately no RemoveNearHeapLimitCallback here: the state that tracked
+    // the installation is already unreachable, so callbackInstalled cannot be
+    // cleared, and the only way to get here is a process on its way out.
+    return current_heap_limit;
+  }
+
   if (state->insideCallback) {
     // Reentrant call detected, try to increase heap limit a bit so that
     // previous callback can proceed

--- a/bindings/profilers/heap.cc
+++ b/bindings/profilers/heap.cc
@@ -435,6 +435,9 @@ size_t NearHeapLimit(void* data,
       state->profile.reset();
     }
   } else {
+    // Drop any profile retained from an earlier invocation: it is stale, and
+    // nothing below is going to consume or replace it.
+    state->profile.reset();
     fprintf(stderr,
             "NearHeapLimit: heap profiler is not enabled, no allocation "
             "profile to report\n");
@@ -535,7 +538,21 @@ NAN_METHOD(HeapProfiler::StartSamplingHeapProfiler) {
 NAN_METHOD(HeapProfiler::StopSamplingHeapProfiler) {
   auto isolate = info.GetIsolate();
   isolate->GetHeapProfiler()->StopSamplingHeapProfiler();
-  PerIsolateData::For(isolate)->GetHeapProfilerState().reset();
+
+  // Uninstall explicitly rather than leaving it to ~HeapProfilerState. reset()
+  // only destroys the state if this is the last reference, and it need not be:
+  // NearHeapLimit and InterruptCallback both take a shared_ptr copy for the
+  // duration of the call, so a stop() reached from inside one of them (the
+  // near-heap-limit JS callback calling heapProfiler.stop(), say) would leave
+  // the state alive, the destructor unrun, and this callback still registered
+  // with V8 while the per-isolate slot is already empty. The next
+  // near-heap-limit GC would then enter NearHeapLimit with no state at all.
+  // Idempotent: it clears callbackInstalled.
+  auto& state = PerIsolateData::For(isolate)->GetHeapProfilerState();
+  if (state) {
+    state->UninstallNearHeapLimitCallback();
+  }
+  state.reset();
 
   // Remove cleanup hook since profiler is explicitly stopped
   {

--- a/bindings/profilers/heap.cc
+++ b/bindings/profilers/heap.cc
@@ -365,6 +365,15 @@ size_t NearHeapLimit(void* data,
   auto isolate = v8::Isolate::GetCurrent();
   auto state = PerIsolateData::For(isolate)->GetHeapProfilerState();
 
+  if (!state) {
+    // StopSamplingHeapProfiler() resets the state but cannot uninstall this
+    // callback — the object that tracked its installation is what it just
+    // dropped. Remove ourselves so we aren't called again, and leave the heap
+    // limit alone so V8 proceeds with its normal OOM handling.
+    isolate->RemoveNearHeapLimitCallback(&NearHeapLimit, 0);
+    return current_heap_limit;
+  }
+
   if (state->insideCallback) {
     // Reentrant call detected, try to increase heap limit a bit so that
     // previous callback can proceed
@@ -541,14 +550,22 @@ NAN_METHOD(HeapProfiler::GetAllocationProfile) {
   if (!profile) {
     return Nan::ThrowError("Heap profiler is not enabled.");
   }
-  const bool allocations = state->allocations;
+  // A non-null profile only proves V8's sampling heap profiler is running; it
+  // does not imply we are the one who started it. Anything else in the process
+  // (the inspector's HeapProfiler.startSampling, another agent) can enable it
+  // without ever going through StartSamplingHeapProfiler, in which case there
+  // is no per-isolate state. Serve the profile without allocation stats rather
+  // than dereferencing an empty shared_ptr.
+  const bool allocations = state && state->allocations;
   v8::AllocationProfile::Node* root = profile->GetRootNode();
   AllocationProfileNodeStatsMap allocation_stats;
   if (allocations) {
     allocation_stats = BuildAllocationStatsByNodeId(profile->GetSamples());
   }
 
-  state->OnNewProfile();
+  if (state) {
+    state->OnNewProfile();
+  }
   info.GetReturnValue().Set(TranslateAllocationProfile(
       root, allocations ? &allocation_stats : nullptr));
 }
@@ -573,7 +590,11 @@ NAN_METHOD(HeapProfiler::MapAllocationProfile) {
     return Nan::ThrowError("Heap profiler is not enabled.");
   }
 
-  state->OnNewProfile();
+  // As in GetAllocationProfile: V8's profiler may be running without us having
+  // started it, so there may be no per-isolate state to update.
+  if (state) {
+    state->OnNewProfile();
+  }
 
   auto root = AllocationProfileNodeView::New(profile->GetRootNode());
   v8::Local<v8::Value> argv[] = {root};
@@ -668,7 +689,9 @@ NAN_MODULE_INIT(HeapProfiler::Init) {
 void InterruptCallback(v8::Isolate* isolate, void* data) {
   v8::HandleScope scope(isolate);
   auto state = PerIsolateData::For(isolate)->GetHeapProfilerState();
-  if (!state->profile) {
+  // The interrupt is requested from NearHeapLimit but runs later, so
+  // StopSamplingHeapProfiler() may have dropped the state in between.
+  if (!state || !state->profile) {
     return;
   }
   v8::Local<v8::Value> argv[1] = {

--- a/bindings/profilers/heap.cc
+++ b/bindings/profilers/heap.cc
@@ -67,12 +67,17 @@ struct HeapProfilerState {
   explicit HeapProfilerState(v8::Isolate* isolate) : isolate(isolate) {}
 
   ~HeapProfilerState() {
+    // Uninstall first. By the time we run, the shared_ptr in PerIsolateData is
+    // already empty (that is what destroyed us), so NearHeapLimit would find no
+    // state to work with; anything below that can trigger a GC must not be able
+    // to reach it.
+    UninstallNearHeapLimitCallback();
+
     auto profiler = isolate->GetHeapProfiler();
     if (profiler) {
       profiler->StopSamplingHeapProfiler();
     }
 
-    UninstallNearHeapLimitCallback();
     if (async) {
       // defer deletion of async when uv_close callback is invoked
       uv_close(reinterpret_cast<uv_handle_t*>(async), [](uv_handle_t* handle) {
@@ -365,15 +370,6 @@ size_t NearHeapLimit(void* data,
   auto isolate = v8::Isolate::GetCurrent();
   auto state = PerIsolateData::For(isolate)->GetHeapProfilerState();
 
-  if (!state) {
-    // StopSamplingHeapProfiler() resets the state but cannot uninstall this
-    // callback — the object that tracked its installation is what it just
-    // dropped. Remove ourselves so we aren't called again, and leave the heap
-    // limit alone so V8 proceeds with its normal OOM handling.
-    isolate->RemoveNearHeapLimitCallback(&NearHeapLimit, 0);
-    return current_heap_limit;
-  }
-
   if (state->insideCallback) {
     // Reentrant call detected, try to increase heap limit a bit so that
     // previous callback can proceed
@@ -410,26 +406,38 @@ size_t NearHeapLimit(void* data,
               stats.object_count());
     }
   }
+  // GetAllocationProfile returns null when V8's sampling heap profiler isn't
+  // running, and that can happen while this callback is still installed:
+  // HeapProfilerCleanupHook stops V8's sampler without touching our state, so
+  // between that hook and the isolate actually going away we stay registered
+  // with nothing to sample. The heap-limit bookkeeping below still has to run,
+  // so skip only the profile-dependent work.
   std::unique_ptr<v8::AllocationProfile> profile{
       isolate->GetHeapProfiler()->GetAllocationProfile()};
-  state->profile = TranslateAllocationProfileToCpp(profile->GetRootNode());
-  if (state->dumpProfileOnStderr) {
-    dumpAllocationProfile(stderr, state->profile.get());
-  }
-
-  if (!state->export_command.empty()) {
-    ExportProfile(*state);
-  }
-
-  if (!state->callback.IsEmpty()) {
-    if (state->callbackMode & kInterruptCallback) {
-      isolate->RequestInterrupt(InterruptCallback, nullptr);
+  if (profile) {
+    state->profile = TranslateAllocationProfileToCpp(profile->GetRootNode());
+    if (state->dumpProfileOnStderr) {
+      dumpAllocationProfile(stderr, state->profile.get());
     }
-    if (state->callbackMode & kAsyncCallback) {
-      uv_async_send(state->async);
+
+    if (!state->export_command.empty()) {
+      ExportProfile(*state);
+    }
+
+    if (!state->callback.IsEmpty()) {
+      if (state->callbackMode & kInterruptCallback) {
+        isolate->RequestInterrupt(InterruptCallback, nullptr);
+      }
+      if (state->callbackMode & kAsyncCallback) {
+        uv_async_send(state->async);
+      }
+    } else {
+      state->profile.reset();
     }
   } else {
-    state->profile.reset();
+    fprintf(stderr,
+            "NearHeapLimit: heap profiler is not enabled, no allocation "
+            "profile to report\n");
   }
 
   if (!state->isMainThread) {

--- a/ts/test/heap-foreign-sampler.ts
+++ b/ts/test/heap-foreign-sampler.ts
@@ -47,12 +47,12 @@ async function main() {
   await post(session, 'HeapProfiler.enable');
   await post(session, 'HeapProfiler.startSampling', {samplingInterval: 16384});
 
-  // Allocate so the sampler actually has samples to report.
+  // Allocate so the sampler actually has samples to report. Kept modest and
+  // scoped to this function: the profile only needs a non-empty sample set.
   const retained: Array<{i: number; s: string}> = [];
-  for (let i = 0; i < 200000; i++) {
+  for (let i = 0; i < 20000; i++) {
     retained.push({i, s: 'x'.repeat(16)});
   }
-  (globalThis as unknown as {__retained: unknown}).__retained = retained;
 
   // pprof never started the heap profiler, so there is no state for this
   // isolate. Both of these must return rather than crash.

--- a/ts/test/heap-foreign-sampler.ts
+++ b/ts/test/heap-foreign-sampler.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2026 Datadog, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+// Runs in a forked process because the failure mode under test is a SIGSEGV,
+// which would take the whole mocha run down with it.
+//
+// V8's sampling heap profiler can be enabled by anything in the process - here
+// the inspector's HeapProfiler.startSampling, but equally DevTools or another
+// agent. That leaves getAllocationProfile()/mapAllocationProfile() with a live
+// V8 profile but no per-isolate HeapProfilerState, since only
+// startSamplingHeapProfiler() creates one. Both used to dereference that empty
+// shared_ptr.
+
+import * as inspector from 'inspector';
+
+import * as v8HeapProfiler from '../src/heap-profiler-bindings';
+
+function post(
+  session: inspector.Session,
+  method: string,
+  params?: object,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    session.post(method, params, err => (err ? reject(err) : resolve()));
+  });
+}
+
+async function main() {
+  const session = new inspector.Session();
+  session.connect();
+
+  await post(session, 'HeapProfiler.enable');
+  await post(session, 'HeapProfiler.startSampling', {samplingInterval: 16384});
+
+  // Allocate so the sampler actually has samples to report.
+  const retained: Array<{i: number; s: string}> = [];
+  for (let i = 0; i < 200000; i++) {
+    retained.push({i, s: 'x'.repeat(16)});
+  }
+  (globalThis as unknown as {__retained: unknown}).__retained = retained;
+
+  // pprof never started the heap profiler, so there is no state for this
+  // isolate. Both of these must return rather than crash.
+  const profile = v8HeapProfiler.getAllocationProfile();
+  if (!profile || typeof profile.name !== 'string') {
+    throw new Error('getAllocationProfile returned an unusable profile');
+  }
+
+  const mapped = v8HeapProfiler.mapAllocationProfile(node => node.name);
+  if (typeof mapped !== 'string') {
+    throw new Error('mapAllocationProfile did not invoke the callback');
+  }
+
+  await post(session, 'HeapProfiler.stopSampling');
+  session.disconnect();
+}
+
+main().then(
+  () => process.exit(0),
+  err => {
+    console.error(err);
+    process.exit(1);
+  },
+);

--- a/ts/test/test-heap-profiler.ts
+++ b/ts/test/test-heap-profiler.ts
@@ -341,6 +341,13 @@ describe('foreign heap sampler', () => {
 
     const proc = fork(path.join(__dirname, 'heap-foreign-sampler.js'), {
       silent: true,
+      // Under the asan CI job the child inherits LD_PRELOAD=libasan and runs
+      // LeakSanitizer at exit. The child ends on process.exit(), so V8's heap
+      // is never torn down and every live object is reported as leaked,
+      // failing the child for reasons that have nothing to do with what this
+      // test checks. ASAN itself stays on, so a genuine memory error in the
+      // code under test is still caught.
+      env: {...process.env, LSAN_OPTIONS: 'detect_leaks=0'},
     });
     let output = '';
     proc.stdout?.on('data', chunk => {
@@ -352,7 +359,9 @@ describe('foreign heap sampler', () => {
 
     await new Promise<void>((resolve, reject) => {
       proc.on('error', reject);
-      proc.on('exit', (code, signal) => {
+      // 'close' rather than 'exit': it fires once the piped stdio has been
+      // drained, so `output` is complete when it lands in the failure message.
+      proc.on('close', (code, signal) => {
         if (code === 0) {
           resolve();
         } else {

--- a/ts/test/test-heap-profiler.ts
+++ b/ts/test/test-heap-profiler.ts
@@ -330,6 +330,43 @@ describe('HeapProfiler', () => {
   });
 });
 
+describe('foreign heap sampler', () => {
+  // Regression test: V8's sampling heap profiler can be enabled by something
+  // other than pprof (inspector, DevTools, another agent). getAllocationProfile
+  // and mapAllocationProfile then see a live V8 profile with no per-isolate
+  // state, and used to dereference an empty shared_ptr. Forked because the
+  // failure is a SIGSEGV.
+  it('should not crash when V8 heap sampling was enabled outside of pprof', async function () {
+    this.timeout(30000);
+
+    const proc = fork(path.join(__dirname, 'heap-foreign-sampler.js'), {
+      silent: true,
+    });
+    let output = '';
+    proc.stdout?.on('data', chunk => {
+      output += chunk;
+    });
+    proc.stderr?.on('data', chunk => {
+      output += chunk;
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      proc.on('error', reject);
+      proc.on('exit', (code, signal) => {
+        if (code === 0) {
+          resolve();
+        } else {
+          reject(
+            new Error(
+              `heap-foreign-sampler exited with code=${code} signal=${signal}\n${output}`,
+            ),
+          );
+        }
+      });
+    });
+  });
+});
+
 describe('OOMMonitoring', () => {
   it('should restore heap limit after v8 recovers from OOM', async function () {
     this.timeout(30000);


### PR DESCRIPTION
## What

`HeapProfiler::GetAllocationProfile` and `HeapProfiler::MapAllocationProfile` dereference the per-isolate `HeapProfilerState` after checking only that V8 returned a profile:

```cpp
auto& state = PerIsolateData::For(isolate)->GetHeapProfilerState();
std::unique_ptr<v8::AllocationProfile> profile(
    isolate->GetHeapProfiler()->GetAllocationProfile());
if (!profile) {
  return Nan::ThrowError("Heap profiler is not enabled.");
}
const bool allocations = state->allocations;   // <- state may be null
```

A non-null profile only proves V8's sampling heap profiler is running — not that *we* started it. Anything else in the process can enable it out of band (the inspector's `HeapProfiler.startSampling`, DevTools, a second agent), and only our own `StartSamplingHeapProfiler` creates the state. The guard then passes with an empty `shared_ptr` and we segfault.

## Why it regressed

Both sites were null-checked through 5.14.4. In 5.15.0 `MonitorOutOfMemory` changed from unconditionally replacing the state to reusing an existing one, which made "state already exists" the normal case; the checks were dropped along the way. `MapAllocationProfile` still null-checks `state` one line above the unguarded `OnNewProfile()` call, which is a good hint that this was accidental.

Restores the pre-5.15.0 behaviour of serving the profile without allocation stats rather than throwing — V8's profiler genuinely is enabled, so `"Heap profiler is not enabled."` would be the wrong error.

## Also fixed

Two pre-existing instances of the same assumption, both reachable because `StopSamplingHeapProfiler()` resets the state:

- **`NearHeapLimit`** read `state->insideCallback` unguarded. The state that recorded the callback's installation is exactly what got dropped, so nothing could uninstall it. Now removes the callback and leaves the heap limit alone so V8 does its normal OOM handling.
- **`InterruptCallback`** is requested from `NearHeapLimit` but runs later, so the state can disappear in between.

## Testing

New `ts/test/heap-foreign-sampler.ts`, forked from `test-heap-profiler.ts` because the failure mode is a SIGSEGV that would otherwise take the whole mocha run down — same pattern as the existing `OOMMonitoring` tests. It enables V8 heap sampling via the inspector and then calls both entry points.

Built the unfixed native code first to confirm the test bites:

```
unfixed:  Error: heap-foreign-sampler exited with code=null signal=SIGSEGV
fixed:    ✔ should not crash when V8 heap sampling was enabled outside of pprof
```

Full suite 113 passing / 0 failing, `clang-format -Werror` clean, `gts check` 0 errors.

## Context

Found while investigating a customer crash on Node.js 20.18.3 / Alpine musl x64 with dd-trace 5.117.0 (`@datadog/pprof` 5.17.0), reported as appearing in 5.15.0+ but not 5.14.4. This is the only defect in the 5.15.0 delta that produces a SIGSEGV, is reachable on Node 20, and still exists in 5.17.0 — `#341`'s PCP list needs CPED (Node >= 22.9) and `#343`'s allocation profiler needs Node >= 26.

It is **not** confirmed to be that customer's crash: it requires a co-tenant enabling V8 heap sampling, and dd-trace never does so itself. The fix stands on its own regardless.

Jira: [PROF-15670]

[PROF-15670]: https://datadoghq.atlassian.net/browse/PROF-15670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ