### PR TITLE
fix(wall): don't derive PersistentContextPtr from node::ObjectWrap

### DIFF
--- a/bindings/profilers/wall.cc
+++ b/bindings/profilers/wall.cc
@@ -106,7 +106,30 @@ void SetContextPtr(ContextPtr& contextPtr,
   }
 }
 
-class PersistentContextPtr : public node::ObjectWrap {
+inline void* GetAlignedPointerFromInternalField(Object* object, int index) {
+#if NODE_MAJOR_VERSION >= 26
+  return object->GetAlignedPointerFromInternalField(
+      index, kEmbedderDataTypeTagDefault);
+#else
+  return object->GetAlignedPointerFromInternalField(index);
+#endif
+}
+
+// Deliberately not a node::ObjectWrap. That base registers a per-instance
+// environment cleanup hook in its constructor and calls
+// RemoveEnvironmentCleanupHook from its destructor, which CHECKs that the
+// Environment is still alive:
+//
+//   node[650]: void node::RemoveEnvironmentCleanupHook(...) hooks.cc:142
+//   Assertion failed: (env) != nullptr
+//
+// A PCP is owned by a weak V8 handle, and V8 runs weak callbacks during
+// isolate teardown — after the Environment has been torn down — so that CHECK
+// fires and aborts the process. All we need from a wrapper is the
+// internal-field pointer and the weak handle, and ~WallProfiler already
+// deletes whatever is still on the live list, so the cleanup hook the base
+// class installs has nothing left to do.
+class PersistentContextPtr {
   ContextPtr context;
   // Back-pointer to the WallProfiler that created this PCP. Guaranteed to be
   // a valid pointer whenever pprev_ != nullptr — ~WallProfiler nulls pprev_
@@ -125,7 +148,16 @@ class PersistentContextPtr : public node::ObjectWrap {
   PersistentContextPtr** pprev_ = nullptr;
   PersistentContextPtr* next_ = nullptr;
 
+  // Weak handle on the holder object. Owns this PCP: when V8 collects the
+  // holder, WeakCallback deletes us.
+  v8::Persistent<v8::Object> handle_;
+
   friend class WallProfiler;
+
+  static void WeakCallback(
+      const v8::WeakCallbackInfo<PersistentContextPtr>& data) {
+    delete data.GetParameter();
+  }
 
  public:
   PersistentContextPtr(WallProfiler* profiler, Local<Object> wrap);
@@ -139,14 +171,18 @@ class PersistentContextPtr : public node::ObjectWrap {
   ContextPtr Get() const { return context; }
 
   static PersistentContextPtr* Unwrap(Local<Object> wrap) {
-    return node::ObjectWrap::Unwrap<PersistentContextPtr>(wrap);
+    return static_cast<PersistentContextPtr*>(
+        GetAlignedPointerFromInternalField(*wrap, 0));
   }
 };
 
 PersistentContextPtr::PersistentContextPtr(WallProfiler* profiler,
                                            Local<Object> wrap)
     : profiler_(profiler) {
-  Wrap(wrap);
+  auto* isolate = Isolate::GetCurrent();
+  wrap->SetAlignedPointerInInternalField(0, this);
+  handle_.Reset(isolate, wrap);
+  handle_.SetWeak(this, &WeakCallback, v8::WeakCallbackType::kParameter);
   // Splice ourselves at the head of profiler's live list.
   auto** headSlot = profiler->liveContextPtrHeadSlot();
   next_ = *headSlot;
@@ -167,15 +203,11 @@ PersistentContextPtr::~PersistentContextPtr() {
     if (next_ != nullptr) next_->pprev_ = pprev_;
     profiler_->recordContextRelease();
   }
-}
-
-inline void* GetAlignedPointerFromInternalField(Object* object, int index) {
-#if NODE_MAJOR_VERSION >= 26
-  return object->GetAlignedPointerFromInternalField(
-      index, kEmbedderDataTypeTagDefault);
-#else
-  return object->GetAlignedPointerFromInternalField(index);
-#endif
+  // Cancels the weak callback when we're deleted by ~WallProfiler rather than
+  // by V8; a no-op when we got here from WeakCallback itself. The holder
+  // object's internal field is left dangling either way, but nothing reads it
+  // once the owning profiler is gone.
+  handle_.Reset();
 }
 
 // Maximum number of rounds in the GetV8ToEpochOffset
@@ -678,9 +710,9 @@ WallProfiler::~WallProfiler() {
   // Delete every PCP still live in the CPED map. ~PCP would normally unlink
   // itself via pprev_/next_, but we're tearing down the list we point into —
   // so null pprev_ first to signal "already detached" and let ~PCP skip the
-  // unlink. (~ObjectWrap will still clear V8's weak callback during delete,
-  // so the dangling internal-field pointer in the wrap object stays inert
-  // even if V8 later GCs the wrap.)
+  // unlink. (~PCP still resets its weak handle during delete, so the dangling
+  // internal-field pointer in the wrap object stays inert even if V8 later
+  // GCs the wrap.)
   auto* p = liveContextPtrHead_;
   while (p != nullptr) {
     auto* next = p->next_;

--- a/bindings/profilers/wall.cc
+++ b/bindings/profilers/wall.cc
@@ -115,6 +115,17 @@ inline void* GetAlignedPointerFromInternalField(Object* object, int index) {
 #endif
 }
 
+inline void SetAlignedPointerInInternalField(Local<Object> object,
+                                             int index,
+                                             void* value) {
+#if NODE_MAJOR_VERSION >= 26
+  object->SetAlignedPointerInInternalField(
+      index, value, kEmbedderDataTypeTagDefault);
+#else
+  object->SetAlignedPointerInInternalField(index, value);
+#endif
+}
+
 // Deliberately not a node::ObjectWrap. That base registers a per-instance
 // environment cleanup hook in its constructor and calls
 // RemoveEnvironmentCleanupHook from its destructor, which CHECKs that the
@@ -180,7 +191,7 @@ PersistentContextPtr::PersistentContextPtr(WallProfiler* profiler,
                                            Local<Object> wrap)
     : profiler_(profiler) {
   auto* isolate = Isolate::GetCurrent();
-  wrap->SetAlignedPointerInInternalField(0, this);
+  SetAlignedPointerInInternalField(wrap, 0, this);
   handle_.Reset(isolate, wrap);
   handle_.SetWeak(this, &WeakCallback, v8::WeakCallbackType::kParameter);
   // Splice ourselves at the head of profiler's live list.


### PR DESCRIPTION
## The abort

`node::ObjectWrap` registers a **per-instance** environment cleanup hook in its constructor, and its destructor calls `RemoveEnvironmentCleanupHook`, which `CHECK`s that the Environment is still alive:

```
node[650]: void node::RemoveEnvironmentCleanupHook(v8::Isolate*, CleanupHook, void*) at ../src/api/hooks.cc:142
Assertion failed: (env) != nullptr
 3: node::RemoveEnvironmentCleanupHook(...)
 4: node::ObjectWrap::RemoveCleanupHook()
 5: node::ObjectWrap::~ObjectWrap()
 6: dd::PersistentContextPtr::~PersistentContextPtr()
 8: node::ObjectWrap::WeakCallback(...)
```

A `PersistentContextPtr` is owned by a weak V8 handle, so V8 decides when it dies — and V8 runs weak callbacks during isolate teardown, after the Environment is gone. The CHECK then aborts the process (SIGABRT, exit 134).

## The fix

The wrapper only ever needed two things from the base class: the internal-field pointer that `GetContextPtrSignalSafe` reads, and a weak handle to hang the object's lifetime on. Neither requires a cleanup hook — `~WallProfiler` already walks the live list and deletes any PCP V8 hasn't collected, which is what keeps LSAN quiet at exit.

So hold the weak `Persistent` directly and drop the base class. `~PersistentContextPtr` resets the handle, which cancels the weak callback when `~WallProfiler` is the one deleting, and is a no-op when we arrived from the callback itself.

## Verification

Reproducible on **unmodified main** — ASAN perturbs GC timing enough to make it deterministic. It surfaces as an abort during teardown right after the Time Profiler tests, so mocha never prints its summary:

| | main | this branch |
|---|---|---|
| `npm run test:js-asan` | exit **134**, aborted | exit **0**, 158 passing |
| LSAN leak reports | — | 0 |
| `npm test` | — | exit 0, 158 passing |

The zero leak count matters: it confirms `~WallProfiler` really is sufficient and the per-instance cleanup hooks were not load-bearing.

Found while CI was red on #384; it is unrelated to that PR's heap-profiler change, which is why it is split out here.

Jira: [PROF-15673]

[PROF-15673]: https://datadoghq.atlassian.net/browse/PROF-15673?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ