### PR TITLE
test(worker-threads): reap the spawned child after a timeout

### DIFF
--- a/ts/test/test-worker-threads.ts
+++ b/ts/test/test-worker-threads.ts
@@ -1,15 +1,32 @@
-import {execFile} from 'child_process';
+import {execFile, ChildProcess} from 'child_process';
 import {promisify} from 'util';
 import {Worker} from 'worker_threads';
 
 const exec = promisify(execFile);
 
 describe('Worker Threads', () => {
+  let child: ChildProcess | undefined;
+
+  afterEach(() => {
+    // A mocha timeout rejects the test but leaves the spawned process running,
+    // and `npm test` runs mocha without --exit, so mocha waits for the event
+    // loop to drain before exiting. A live child keeps its process handle on
+    // the loop, so a child that outlives its test holds the entire run open —
+    // if that child is itself wedged, until the CI job limit rather than until
+    // the test times out. Hooks still run after a timeout, so reap it here.
+    if (child?.exitCode === null && child.signalCode === null) {
+      child.kill();
+    }
+    child = undefined;
+  });
+
   // eslint-ignore-next-line prefer-array-callback
   it('should work', function () {
     this.timeout(20000);
     const nbWorkers = 2;
-    return exec('node', ['./out/test/worker.js', String(nbWorkers)]);
+    const running = exec('node', ['./out/test/worker.js', String(nbWorkers)]);
+    child = running.child;
+    return running;
   });
 
   it('should not crash when worker is terminated', async function () {


### PR DESCRIPTION
## Symptom

`win32-test-22` on #385 printed its mocha epilogue inside the first minute, then sat `in_progress` on `Run ./.prebuildify/test` for **half an hour**:

```
✔ should not crash when worker is terminated (19288ms)
91 passing (1m)
1 failing
1) Worker Threads should work:
   Error: Timeout of 20000ms exceeded.
```

Tests done in a minute, job still running 30 minutes later.

<img width="1341" height="803" alt="Screenshot 2026-08-07 at 09 44 00" src="https://github.com/user-attachments/assets/32a1c955-b509-4e7b-91c6-35bf6e278799" />

## Cause

A mocha timeout rejects the test but does not kill the process the test spawned, and `npm test` is `nyc mocha …` with **no `--exit`**, so mocha waits for the event loop to drain before exiting. A live child keeps its process handle on that loop, so a child that outlives its test holds the entire run open.

When the child is merely slow this is invisible — mocha waits the extra couple of seconds and exits, which is why it never shows up on Linux (`worker.js` finishes in ~4.5s there). When the child is *wedged*, the run never ends and the job burns a runner until the CI job limit instead of failing in ~20s.

## Fix

`promisify(execFile)` exposes the `ChildProcess` on the returned promise, so capture it and kill it from `afterEach` — mocha still runs hooks after a timeout. Measured locally with the child replaced by a 10-minute sleep and the test timeout forced low:

| | total |
| --- | --- |
| with the reap | **1.19s** |
| without the reap | never exits (killed by a 30s watchdog) |

Chose this over adding `--exit` to the mocha invocation: `--exit` would paper over any handle leak, and this suite exists partly to catch worker threads that fail to exit.

## Scope

This **bounds the damage only**. It does not address why that child wedges on win32, which is the actual bug and a separate investigation. It is worth noting that Windows takes the plain V8 `CpuProfiler` path (no SIGPROF, and `worker.js` sets `withContexts`/`useCPED` to false off-platform), and this codebase already carries `detectV8Bug` / `v8ProfilerStuckEventLoopDetected` machinery for V8 sampler stalls.

Also unaddressed here: `should work` has a 20s budget while its heavier in-process sibling gets 30s, and Windows runs these ~10x slower than Linux. That inconsistency is worth revisiting, but raising the timeout would not have fixed this run — the parent waits on the child regardless of the test timeout.