### PR TITLE
fix(wall): hold the PCP holder in a Global, not a Persistent

### DIFF
--- a/bindings/profilers/wall.cc
+++ b/bindings/profilers/wall.cc
@@ -161,7 +161,7 @@ class PersistentContextPtr {
 
   // Weak handle on the holder object. Owns this PCP: when V8 collects the
   // holder, WeakCallback deletes us.
-  v8::Persistent<v8::Object> handle_;
+  v8::Global<v8::Object> handle_;
 
   friend class WallProfiler;
 
@@ -214,11 +214,6 @@ PersistentContextPtr::~PersistentContextPtr() {
     if (next_ != nullptr) next_->pprev_ = pprev_;
     profiler_->recordContextRelease();
   }
-  // Cancels the weak callback when we're deleted by ~WallProfiler rather than
-  // by V8; a no-op when we got here from WeakCallback itself. The holder
-  // object's internal field is left dangling either way, but nothing reads it
-  // once the owning profiler is gone.
-  handle_.Reset();
 }
 
 // Maximum number of rounds in the GetV8ToEpochOffset


### PR DESCRIPTION
Review follow-up on #385 (@nsavoire's two nits, both landed after merge).

## Persistent -> Global

`v8::Persistent` has no destruction behaviour — the handle leaks unless every path clears it by hand. `v8::Global` releases it in its own destructor, and is what every other handle in this file already uses: `ContextPtr`, `cpedKey_`, `wrapObjectTemplate_`, `jsArray_`. The `Persistent` I introduced in #385 was the odd one out.

Nothing was actually leaking, since `~PersistentContextPtr` always reset the handle explicitly — but relying on that is exactly the footgun the docs warn about. With `Global` the release becomes structural, so the explicit `Reset()` goes away with it.

Worth recording why the manual handle existed at all: before #261 removed instance reuse, `PersistentContextPtr` recycled itself through a freelist and needed `ClearWeak`/`Reset` to unregister and re-register the *same* object. With reuse gone, a handle lives exactly as long as its PCP, so there's nothing left for `Persistent`'s manual semantics to buy.