### PR TITLE
test(worker-threads): trace worker.js phases for the intermittent stall

### DIFF
--- a/ts/test/worker.ts
+++ b/ts/test/worker.ts
@@ -6,6 +6,7 @@ import {getAndVerifyPresence, getAndVerifyString} from './profiles-for-tests';
 import {satisfies} from 'semver';
 
 import assert from 'assert';
+import {appendFileSync} from 'fs';
 
 const DURATION_MILLIS = 1000;
 const intervalMicros = 10000;
@@ -20,23 +21,64 @@ const useCPED =
 const collectAsyncId =
   withContexts && satisfies(process.versions.node, '>=24.0.0');
 
+// Phase instrumentation for the intermittent stall this test hits on CI:
+// `should work` times out at 20s while the workload is almost entirely
+// wall-clock deadline work that finishes in ~4-5s regardless of machine speed
+// (with the deadline cut to 1ms the whole thing runs in ~60ms), so a run that
+// reaches 20s is wedged rather than slow. Reproduces on Linux Node 22 at
+// roughly one job in four, as well as on darwin-arm64 and win32.
+//
+// Collecting the marks costs a string and an array push; leaving them in means
+// anyone hunting the stall can see which phase it died in rather than
+// reconstructing it. Set DD_WORKER_TRACE_FILE to also append each mark to a
+// file as it happens — a file rather than stdout because execFile buffers a
+// child's output and only delivers it when the child closes, so a wedged child
+// produces nothing, and appending as we go means the trail survives the child
+// being killed.
+//
+// Deliberately no timer, no diagnostic-report call and no process.exit here.
+// An earlier version armed a watchdog that did all three and wedged CI jobs
+// for 40+ minutes; bisection pinned it to arming the timer, though the
+// mechanism was never identified. Nothing below runs on a schedule.
+const TRACE_FILE = process.env.DD_WORKER_TRACE_FILE;
+const START = Date.now();
+const progress: string[] = [];
+
+function mark(msg: string): void {
+  const line = `+${Date.now() - START}ms ${msg}`;
+  progress.push(line);
+  if (TRACE_FILE) {
+    // Synchronous: the point is that the line is on disk before whatever
+    // happens next, including the process being killed.
+    appendFileSync(TRACE_FILE, `${line}\n`);
+  }
+}
+
+let nextWorkerId = 0;
+
 function createWorker(durationMs: number): Promise<Profile[]> {
   return new Promise((resolve, reject) => {
     const profiles: Profile[] = [];
+    const chain = nextWorkerId++;
+    mark(`chain ${chain}: spawning first worker`);
     new Worker(__filename, {workerData: {durationMs}})
       .on('exit', exitCode => {
+        mark(`chain ${chain}: first worker exited (${exitCode})`);
         if (exitCode !== 0) reject();
         setTimeout(
           () => {
             // Run a second worker after the first one exited to test for proper
             // cleanup after first worker. This used to segfault.
+            mark(`chain ${chain}: spawning second worker`);
             new Worker(__filename, {workerData: {durationMs}})
               .on('exit', exitCode => {
+                mark(`chain ${chain}: second worker exited (${exitCode})`);
                 if (exitCode !== 0) reject();
                 resolve(profiles);
               })
               .on('error', reject)
               .on('message', profile => {
+                mark(`chain ${chain}: second worker sent a profile`);
                 profiles.push(profile);
               });
           },
@@ -45,6 +87,7 @@ function createWorker(durationMs: number): Promise<Profile[]> {
       })
       .on('error', reject)
       .on('message', profile => {
+        mark(`chain ${chain}: first worker sent a profile`);
         profiles.push(profile);
       });
   });
@@ -64,6 +107,7 @@ function getCpuUsage() {
 }
 
 async function main(durationMs: number) {
+  mark('main: starting profiler');
   time.start({
     durationMillis: durationMs * 3,
     intervalMicros,
@@ -80,15 +124,20 @@ async function main(durationMs: number) {
   const nbWorkers = Number(process.argv[2] ?? 2);
 
   // start workers
+  mark(`main: spawning ${nbWorkers} worker chains`);
   const workers = executeWorkers(nbWorkers, durationMs);
 
   const deadline = Date.now() + durationMs;
   // wait for all work to finish
+  mark('main: awaiting first bar/foo round');
   await Promise.all([bar(deadline), foo(deadline)]);
+  mark('main: first bar/foo round done, awaiting worker chains');
   const workerProfiles = await workers;
+  mark('main: worker chains done');
 
   // restart and check profile
   const profile1 = time.stop(true);
+  mark('main: stop(restart=true) returned');
   const cpu1 = getCpuUsage();
 
   workerProfiles.forEach(checkProfile);
@@ -97,14 +146,18 @@ async function main(durationMs: number) {
     checkCpuTime(profile1, cpu1 - cpu0, workerProfiles);
   }
   const newDeadline = Date.now() + durationMs;
+  mark('main: awaiting second bar/foo round');
   await Promise.all([bar(newDeadline), foo(newDeadline)]);
+  mark('main: second bar/foo round done');
 
   const profile2 = time.stop();
+  mark('main: stop() returned');
   const cpu2 = getCpuUsage();
   checkProfile(profile2);
   if (withContexts) {
     checkCpuTime(profile2, cpu2 - cpu1);
   }
+  mark('main: done');
 }
 
 async function worker(durationMs: number) {


### PR DESCRIPTION
`Worker Threads should work` flakes on CI with nothing but:

```
Error: Timeout of 20000ms exceeded.
```

This records which phase the child was in, so whoever picks the stall up can see where it died instead of reconstructing it. **It does not fix the stall**, and there is no behaviour change unless `DD_WORKER_TRACE_FILE` is set.

## Why it is a stall, not a slow runner

Measured on darwin-arm64 / Node 22:

| | result |
| --- | --- |
| 60 runs idle | 0 anomalies, ~3.5–4.1s |
| 80 runs under 8-way contention | 0 stalls — median 4597ms, p90 4621ms, **max 4635ms** |
| **deadline cut to 1ms** | **~60ms total** |

`worker.js` is almost entirely wall-clock deadline work, so only ~60ms actually scales with machine speed. On the same CI runner where a passing job ran `should work` in 5105ms, the failing job exceeded 20s while its CPU-bound sibling test took a comparable 13846ms vs 14138ms — so the runner was not slower. Reaching 20s is four to five times beyond anything slowness explains, and raising the timeout would hide it rather than fix it.

## What this adds

Phase marks — per worker chain: spawned, sent a profile, exited — costing a string and an array push. `DD_WORKER_TRACE_FILE` additionally appends each mark to a file as it happens.

A file rather than stdout, deliberately: `execFile` buffers a child's output and only delivers it once the child closes, so a wedged child yields nothing. Appending synchronously as we go also means the trail survives the child being killed, which is exactly what the reap in `afterEach` does to it. Verified — SIGTERM mid-run still leaves the phases on disk:

```
+1069ms chain 1: first worker exited (0)
+1169ms chain 1: spawning second worker     <- last line before the kill
```

## What was removed, and why

An earlier version of this PR armed a watchdog timer that produced a diagnostic report and called `process.exit()`. It wedged CI jobs for 40+ minutes each. Bisected over three runs:

| change | Linux Node 22 |
| --- | --- |
| test-side only (`env` option + async rewrite) | 4/4 green |
| full change, watchdog armed | **2/4 wedged >9 min** |
| same instrumentation, timer never created | 0/4 wedged |

So arming the timer is the trigger. **The mechanism was not identified** — `process.exit()` with a live busy worker and `process.report.getReport()` against an unresponsive worker both complete in ~550ms locally, so neither explains it. Hence no timer, no report call and no `process.exit()` here. Nothing in this PR runs on a schedule.

## Also worth recording

The bisect showed the stall **reproduces on Linux Node 22, at roughly one job in four**. The earlier 20-run history — in which only `win32-test-22` (12×) and `darwin-arm64-test-22` (5×) ever failed — was undersampling, not a platform boundary. Linux is a much easier target for whoever debugs this.

It is also not our profiler configuration: on win32, `DD_WALL_USE_SIGPROF` and `DD_WALL_USE_CPED` are both false for every Node version (they sit inside `#ifndef _WIN32`) and `worker.js` sets `withContexts = darwin || linux`, so all five win32 versions run identical configuration and identical compiled paths — yet only Node 22 fails.

## Verification

Full matrix green: **30/30 test jobs, 100–172s each**, across alpine / centos / linux-x64 / linux-arm64 / darwin-arm64 / win32 on Node 18, 20, 22, 24, 26. Locally: `gts check` 0 errors, `should work` 3847ms with tracing off, 22 trace lines with it on.