### PR TITLE
fix(otel-thread-ctx): don't assert a record is valid when growing it

### DIFF
--- a/bindings/otel-thread-ctx.cc
+++ b/bindings/otel-thread-ctx.cc
@@ -614,14 +614,21 @@ void CtxWrap::Append(const FunctionCallbackInfo<Value>& args) {
     isolate->ThrowError("allocation failed");
     return;
   }
+  // Capture before the copy: the point of the assert below is that the memcpy
+  // carried the header across intact, not that the record is valid. It used to
+  // assert `valid == 1`, which invalidate() legitimately makes false — and
+  // since NDEBUG is not defined for this addon, that aborted release builds
+  // too, not just debug ones.
+  const uint8_t src_valid = self->record_->valid;
   // Copy the existing record (header + already-written attrs_data).
   memcpy(
       new_rec.get(), self->record_, sizeof(OtelThreadCtxRecord) + current_used);
   // Append the new entries and update attrs_data_size.
   memcpy(&new_rec->attrs_data[current_used], appended.data(), appended.size());
   new_rec->attrs_data_size = static_cast<uint16_t>(new_used);
-  // The copy should've preserved valid=1 from the source record.
-  assert(new_rec->valid == 1);
+  // The copy should've carried the source record's header across verbatim,
+  // whatever its validity was.
+  assert(new_rec->valid == src_valid);
 
   // Publish: the pointer swap is the atomic boundary the reader sees. The
   // first fence keeps the new_rec content writes ordered before the pointer

--- a/ts/test/otel-invalidate-append.ts
+++ b/ts/test/otel-invalidate-append.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 Datadog, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+// Runs in a forked process because the failure mode is an abort, which would
+// take the whole mocha run down with it.
+//
+// Append's reallocate path used to assert that the copied record had
+// `valid == 1`. invalidate() sets that byte to 0 and appending afterwards is
+// supported, so an append too large to fit in place aborted the process:
+//
+//     Assertion `new_rec->valid == 1' failed.
+//
+// Only the reallocate path is affected — an append that fits the current
+// capacity is written in place and never copies the header. A fresh record has
+// 36 bytes of attrs_data capacity (64 - sizeof(header)), so the value below is
+// comfortably past it.
+
+import assert from 'assert';
+
+import {otelThreadCtx} from '../src/index';
+
+const VALUE = 'x'.repeat(200);
+
+const ctx = new otelThreadCtx.ThreadContext(
+  Buffer.alloc(16, 1),
+  Buffer.alloc(8, 2),
+);
+
+ctx.run(() => {
+  ctx.invalidate();
+  ctx.appendAttributes([VALUE]);
+
+  const bytes = ctx.debugBytes();
+  const attrsDataSize = bytes[26] | (bytes[27] << 8);
+
+  // invalidate() must stick: growing the record does not resurrect it.
+  assert.strictEqual(bytes[24], 0, 'valid byte should still be 0');
+  // key index (1) + length (1) + the value itself.
+  assert.strictEqual(attrsDataSize, VALUE.length + 2, 'attrs_data_size');
+});
+
+console.log('ok');

--- a/ts/test/test-otel-thread-ctx.ts
+++ b/ts/test/test-otel-thread-ctx.ts
@@ -770,6 +770,45 @@ function captureBytes(opts: {
       });
     });
 
+    describe('invalidate then grow', () => {
+      // Regression test: Append's reallocate path asserted that the copied
+      // record had valid == 1, which invalidate() legitimately makes false, so
+      // an append too large to fit in place aborted the process. NDEBUG is not
+      // defined for this addon, so that hit release builds too. The sibling
+      // test above appends 6 bytes, which fits the initial 36-byte capacity and
+      // is written in place, so it never reached the copy. Forked, because the
+      // failure is an abort rather than a test failure.
+      it('should survive an append that reallocates after invalidate', async function () {
+        this.timeout(30000);
+
+        const proc = fork(join(__dirname, 'otel-invalidate-append.js'), {
+          silent: true,
+        });
+        let output = '';
+        proc.stdout?.on('data', chunk => {
+          output += chunk;
+        });
+        proc.stderr?.on('data', chunk => {
+          output += chunk;
+        });
+
+        await new Promise<void>((resolve, reject) => {
+          proc.on('error', reject);
+          proc.on('close', (code, signal) => {
+            if (code === 0) {
+              resolve();
+            } else {
+              reject(
+                new Error(
+                  `otel-invalidate-append exited with code=${code} signal=${signal}\n${output}`,
+                ),
+              );
+            }
+          });
+        });
+      });
+    });
+
     describe('getProcessContextAttributes', () => {
       it('rejects non-array keys', () => {
         strictAssert.throws(


### PR DESCRIPTION
Reported by @nsavoire on #391. Confirmed, and more serious than "fires in debug builds".

## The bug

`Append`'s reallocate path asserts that the record it just copied is valid:

```cpp
memcpy(new_rec.get(), self->record_, sizeof(OtelThreadCtxRecord) + current_used);
...
// The copy should've preserved valid=1 from the source record.
assert(new_rec->valid == 1);
```

`invalidate()` sets that byte to 0, and appending afterwards is supported — there is a test asserting exactly that — so the memcpy faithfully copies a 0 and the assert fires.

**It is not debug-only.** `NDEBUG` is never defined for this addon (nothing in `dd_pprof.target.mk` defines it), so `assert()` is live in Release as well. Both configurations abort. Reproduced through the public API on Linux:

```js
const ctx = new ThreadContext(traceId, spanId);
ctx.run(() => {
  ctx.invalidate();                        // span finished
  ctx.appendAttributes(['x'.repeat(200)]);  // late attribute
});
```

```
node: ../bindings/otel-thread-ctx.cc:625:
  Assertion `new_rec->valid == 1' failed.
Aborted (exit 134)
```

Only the reallocate path is affected — an append that fits the current capacity is written in place and never copies the header. A fresh record has 36 bytes of attrs_data capacity (`64 - sizeof(header)`), so an attribute over ~34 bytes on a fresh record is enough to trigger it.

## Why the existing test missed it

`appendAttributes after invalidate mutates attrs_data but leaves valid=0` appends `'late'` — 6 bytes. That fits the initial capacity, takes the in-place path, and never reaches the copy. Right behaviour under test, wrong size.

## The fix

Assert what the check was actually for — that the memcpy carried the header across intact — rather than a value the API legitimately changes:

```cpp
const uint8_t src_valid = self->record_->valid;   // before the copy
...
assert(new_rec->valid == src_valid);
```

Still catches a genuine copy bug (shortening the memcpy so it no longer covers the header) and is correct whether the record is valid or not.

## Verification

The regression test forks, since the failure is an abort that would otherwise take the whole mocha run down — same pattern as the teardown test in this file. Built the pre-fix C++ against it to confirm it bites:

| | result |
| --- | --- |
| new test vs **pre-fix** binding | `exited with code=null signal=SIGABRT` + the assertion |
| new test vs fixed binding | passing |
| Node 24 `npm test` | exit 0, 166 passing |
| Node 26 `npm test` | exit 0, 166 passing |
| Node 20 `test:js-asan` | exit 0, 101 passing, 0 leaks |
| public-API repro | exit 0 |

`clang-format -Werror` clean, `gts check` 0 errors.

## Follow-up

The same code is vendored in `custom-labels` `js/addon.cpp` and needs the same fix; happy to port once this lands.

Worth considering separately: `NDEBUG` not being defined means every `assert()` in these bindings is live in production. That is arguably fine as a fail-fast policy, but it should be a deliberate choice — this one was a wrong assertion shipping as a release-build abort.