### PR TITLE
chore(deps): bump pprof-format to 2.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "node-gyp-build": "^4.8.4",
-        "pprof-format": "^2.3.0",
+        "pprof-format": "^2.3.1",
         "source-map": "^0.8.0"
       },
       "devDependencies": {
@@ -5062,9 +5062,9 @@
       }
     },
     "node_modules/pprof-format": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pprof-format/-/pprof-format-2.3.0.tgz",
-      "integrity": "sha512-ovChRLoV4H3k0zKWq0AXewtnuPGskzBLjBPmF2N0DZu+H65PYuo51+6e/1GTb8Olm7oC0xvhhLdqPL4/XhCl4A==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/pprof-format/-/pprof-format-2.3.1.tgz",
+      "integrity": "sha512-y51Z83qG2vEQBACPu6lkGFREVkHwQaCaNDdSFEMLIqSo3bmpADsbP6J3F2SSk7tYB741oTQ9Kt5YAdQsmiCRkA==",
       "license": "MIT"
     },
     "node_modules/prelude-ls": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "node-gyp-build": "^4.8.4",
-    "pprof-format": "^2.3.0",
+    "pprof-format": "^2.3.1",
     "source-map": "^0.8.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Moves `pprof-format` from `^2.3.0` to `^2.3.1` and repins the lockfile.

## What is actually in 2.3.1

Diffing the published tarballs, `package.json` is the **only** file that differs:

```
$ diff -rq pprof-format-2.3.0/package pprof-format-2.3.1/package
Files a/package/package.json and b/package/package.json differ
```

and within it: the version, two devDependency bumps (`@types/node`, `eslint`), and an `overrides` block pinning `brace-expansion` and `linkify-it` in pprof-format's own dev tree.

`pprof-format` has no runtime dependencies, and a dependency's `overrides` are ignored by npm — only the root project's apply. So **no shipped code changes here, and no vulnerability we are exposed to is fixed.** It keeps us on the current release and off tooling's "behind latest" reports; that is the whole of it. Flagging it so nobody reads the CVE-shaped commit titles upstream and assumes otherwise.

`^2.3.0` already admitted 2.3.1, so the substantive part is the lockfile pin. The range moves in step so the declared floor matches what CI tests against.

## Diff scope

Confined to `pprof-format`: one line in `package.json`, and the version/resolved/integrity triple plus the dependency spec in `package-lock.json`. Nothing else in the lock moved.

## Verification

Full suite 115 passing, `gts check` 0 errors, addon builds clean.