### PR TITLE
fix(wall): don't touch V8 handles in ~WallProfiler

### DIFF
--- a/bindings/otel-thread-ctx.cc
+++ b/bindings/otel-thread-ctx.cc
@@ -301,7 +301,12 @@ thread_local CtxWrap* g_live_ctx_wraps = nullptr;
 // fires exactly once, at teardown, while the Environment is still alive.
 void DrainLiveCtxWraps(void* arg) {
   auto* isolate = static_cast<Isolate*>(arg);
+  // We must allocate our own HandleScope here as node::FreeEnvironment wraps
+  // RunCleanup in a SealHandleScope, so handle_.Get() below has to allocate
+  // inside a scope of our own or V8 aborts with "Cannot create a handle without
+  // a HandleScope".
   v8::HandleScope scope(isolate);
+
   CtxWrap* p = g_live_ctx_wraps;
   while (p != nullptr) {
     CtxWrap* next = p->next_;

--- a/bindings/profilers/wall.cc
+++ b/bindings/profilers/wall.cc
@@ -700,15 +700,19 @@ WallProfiler::~WallProfiler() {
   // unlink. (~PCP still resets its weak handle during delete, so the dangling
   // internal-field pointer in the wrap object stays inert even if V8 later
   // GCs the wrap.)
+  //
+  // While it'd be tempting to do the same "zero out internal field logic" here
+  // as in otel-thread-ctx.cc's DrainLiveCtxWraps, we shouldn't. That one only
+  // ever runs as an environment cleanup hook, while this can also get here from
+  // Nan::ObjectWrap's weak callback, and V8 forbids the API in a first-pass
+  // weak callback. The holders' internal fields therefore keep pointing at the
+  // PCPs we free, but since they are only ever read back through our own
+  // cpedKey_ that dies with us it is not an issue.
   auto* p = liveContextPtrHead_;
-  auto isolate = Isolate::GetCurrent();
   while (p != nullptr) {
     auto* next = p->next_;
     p->pprev_ = nullptr;
     p->next_ = nullptr;
-    if (isolate != nullptr && !p->handle_.IsEmpty()) {
-      SetAlignedPointerInInternalField(p->handle_.Get(isolate), 0, nullptr);
-    }
     delete p;
     p = next;
   }

--- a/ts/test/worker2.ts
+++ b/ts/test/worker2.ts
@@ -24,8 +24,22 @@ time.start({
   useCPED: useCPED,
 });
 
-parentPort?.on('message', () => {
-  void delay(50).then(() => {
-    parentPort?.postMessage('hello');
+function listen() {
+  parentPort?.on('message', () => {
+    void delay(50).then(() => {
+      parentPort?.postMessage('hello');
+    });
   });
-});
+}
+
+// Establish a sample context, and do it around the listener registration so
+// the async context frame holding it stays reachable until we are terminated.
+// That leaves a live PersistentContextPtr for ~WallProfiler to walk when it
+// runs from the environment cleanup hook; with an empty list the walk is a
+// no-op and the teardown path goes untested.
+if (useCPED) {
+  time.runWithContext({worker: 'worker2'}, listen);
+} else {
+  time.setContext({worker: 'worker2'});
+  listen();
+}


### PR DESCRIPTION
Fixes the 5.18.0 regression reported as [DataDog/dd-trace-js#9891](https://github.com/DataDog/dd-trace-js/issues/9891): terminating a worker thread with profiling enabled aborts the process.

```
FATAL ERROR: v8::HandleScope::CreateHandle() Cannot create a handle without a HandleScope

 4: v8::HandleScope::CreateHandle(v8::internal::Isolate*, unsigned long)
 5: dd::WallProfiler::~WallProfiler()          [dd_pprof.node]
 6: dd::WallProfiler::CleanupHook(void*)       [dd_pprof.node]
 7: node::CleanupQueue::Drain()
 8: node::Environment::RunCleanup()
 9: node::FreeEnvironment(node::Environment*)
10: node::worker::Worker::Run()
```

## Cause

`e0ce2c2` (#391), second commit — "Add the zero-out-internal-field logic to PCP too". 

On its surface, this could be fixed by adding a `HandleScope` to `~WallProfiler`, but it unfortunately doesn't fully fix the problem, because we can invoke `~WallProfiler` through the `WeakCallback` of `Nan::ObjectWrap`. V8 docs say

> When a weak callback is first invoked the embedders _must_ Reset() the handle which triggered the callback. **No other V8 API calls may be called in the first callback.**

This is something we clearly violate here. Turns out V8 release build doesn't _actually_ police this today, but where the holders die in the same GC nothing orders their weak callbacks before the profiler's, so `Get()` can materialize a `Local` to an already-condemned object and write its internal field.

And in the end, this code isn't needed: a PCP holder is reachable only through *that profiler's* `cpedKey_`. Another `WallProfiler` in the same isolate uses a different key object. The slot dies with the only thing that could have read it so it doesn't matter whether it's zero'd out or not. So this restores 5.17.0 behavior for PCP.

## Extending the tests so they catch this

`test-worker-threads.ts` already terminates 100 workers, but `worker2.ts` never set a sample context so `liveContextPtrHead_` was always empty and the faulting walk never ran. I've now extended it so that it establishes one sample context around the listener registration, so the frame holding it stays reachable until termination.

Jira: [PROF-15797]

[PROF-15797]: https://datadoghq.atlassian.net/browse/PROF-15797?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ