### PR TITLE
Gate reader discovery on cped_slot rather than undefined_addr

### DIFF
--- a/bindings/otel-thread-ctx.cc
+++ b/bindings/otel-thread-ctx.cc
@@ -775,7 +775,12 @@ void CtxWrap::Init(Local<Object> exports) {
 // this as a per-isolate cleanup hook the first time StoreAls is called
 // keeps the handle safely scoped to the isolate.
 void ResetDiscoveryStruct(void* /*arg*/) {
-  otel_thread_ctx_nodejs_v1.cped_slot = nullptr;
+  // Clear cped_slot with volatile + signal fence so a reader that stops this
+  // thread mid-teardown either sees a null cped_slot and bails, or sees the
+  // struct still whole.
+  *reinterpret_cast<v8::internal::Address* volatile*>(
+      &otel_thread_ctx_nodejs_v1.cped_slot) = nullptr;
+  std::atomic_signal_fence(std::memory_order_release);
   otel_thread_ctx_nodejs_v1.als_handle.Reset();
   otel_thread_ctx_nodejs_v1.als_identity_hash = 0;
   otel_thread_ctx_nodejs_v1.undefined_addr = 0;
@@ -791,25 +796,23 @@ void StoreAls(const FunctionCallbackInfo<Value>& args) {
   otel_thread_ctx_nodejs_v1.als_identity_hash = obj->GetIdentityHash();
   otel_thread_ctx_nodejs_v1.als_handle = Global<Object>(isolate, obj);
 #if NODE_MAJOR_VERSION >= 22
-  otel_thread_ctx_nodejs_v1.cped_slot =
-      reinterpret_cast<v8::internal::Address*>(
-          reinterpret_cast<char*>(isolate) +
-          v8::internal::Internals::kContinuationPreservedEmbedderDataOffset);
+  v8::internal::Address* slot = reinterpret_cast<v8::internal::Address*>(
+      reinterpret_cast<char*>(isolate) +
+      v8::internal::Internals::kContinuationPreservedEmbedderDataOffset);
 #else
   // Node < 22 lacks ContinuationPreservedEmbedderData entirely (and the
   // associated V8 internal offset). The TS layer refuses to install the
   // hook on these versions via isAsyncContextFrameActive, so StoreAls is
-  // never called from JS — this null assignment is just here so the
-  // addon compiles on the older Node versions the package supports.
-  otel_thread_ctx_nodejs_v1.cped_slot = nullptr;
+  // never called from JS — this null assignment is here so the addon
+  // compiles on the older Node versions the package supports and also
+  // cped_slot == nullptr serves as the reader gate.
+  v8::internal::Address* slot = nullptr;
 #endif
-  // `undefined_addr == 0` doubles as the "not yet initialized on this
-  // isolate" flag: it starts at zero (thread-local zero-init), any real
-  // V8 undefined singleton address is non-zero, and ResetDiscoveryStruct
-  // clears it back to zero — so a subsequent StoreAls (e.g. isolate
-  // tear-down then re-init on the same thread) re-registers the cleanup
-  // hook. Register BEFORE the write so the flag transition is the last
-  // observable step.
+  // `undefined_addr == 0` marks "no cleanup hook registered for this thread
+  // yet": it starts at zero (thread-local zero-init) and ResetDiscoveryStruct
+  // clears it back to zero, so an isolate re-initialized on this thread
+  // registers a fresh hook. This is bookkeeping for us, not the reader's
+  // gate, we use cped_slot for that.
   if (otel_thread_ctx_nodejs_v1.undefined_addr == 0) {
     node::AddEnvironmentCleanupHook(isolate, ResetDiscoveryStruct, nullptr);
   }
@@ -818,6 +821,14 @@ void StoreAls(const FunctionCallbackInfo<Value>& args) {
   // address is fine — no Global<> tracking needed.
   otel_thread_ctx_nodejs_v1.undefined_addr =
       reinterpret_cast<v8::internal::Address>(*v8::Undefined(isolate));
+
+  // Write `cped_slot` last with signal fence + volatile. It is what a reader
+  // tests before it dereferences anything, so publishing it after every other
+  // field means a reader either sees null and bails or sees a fully populated
+  // struct.
+  std::atomic_signal_fence(std::memory_order_release);
+  *reinterpret_cast<v8::internal::Address* volatile*>(
+      &otel_thread_ctx_nodejs_v1.cped_slot) = slot;
 }
 
 // Without a function that explicitly reads the TLS variable, on x86 the


### PR DESCRIPTION
Makes `cped_slot` the field that the reader checks before it dereferences anything, and orders the writes to the thread local structure around it so it's written last on construction and cleared first on destruction.

I'm in the process of writing an OTEP specification for the Node.js thread context protocol, so I'm ironing out some wrinkles I'm coming across with observable ordering of writes etc.

### Why `cped_slot` rather than `undefined_addr`

Our initial recommendation was to check `undefined_addr` not being zero for this, but it was actually serving two purposes: the value a reader compares against to detect "no context attached", *and* the liveness flag. 

I decided to instead use `cped_slot` for the liveness, for the following reasons:
* It's the first pointer the reader needs to dereference, so it makes sense for it to act as the gate. `cped_slot != 0` says "there is a slot to read", and `undefined_addr != 0` says "someone initialized this struct at some point".
* The two already disagree on Node < 22, where `cped_slot` remains null because that V8 has no CPED but `undefined_addr` is set to non-zero. (We keep using `undefined_addr != 0` as our internal "someone initialized this struct" signal, though.)

### The ordering

This really started out as an a-ha moment of "if undefined_addr is used by the reader as a gate, then I must make sure its initialization order is guaranteed", which then led me to "wait, why are we using undefined_addr and not cped_slot for this?".

And to boot, the order for `undefined_addr` gate was actually wrong, as it was cleared last so it'd still be nonzero in front of other already-cleared fields and the reader can stop the thread while this is happening and observe the inconsistency. This was harmless in practice only because the cleared fields are null and cross-process reads of address 0 fail, so… safety by accident.

Both stores are now `volatile` behind an `atomic_signal_fence` and ordered to happen correctly.